### PR TITLE
custom output path for report.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.DS_Store

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ use crate::detect::detector::{get_all_detectors, IssueSeverity};
 use crate::report::printer::{MarkdownReportPrinter, ReportPrinter};
 use crate::report::reporter::{Issue, Report};
 
-pub fn run(context_loader: ContextLoader) -> Result<(), Box<dyn Error>> {
+pub fn run(context_loader: ContextLoader, output_file_path: String) -> Result<(), Box<dyn Error>> {
     println!("Get Detectors");
 
     let detectors = get_all_detectors();
@@ -57,13 +57,21 @@ pub fn run(context_loader: ContextLoader) -> Result<(), Box<dyn Error>> {
 
     let printer = MarkdownReportPrinter;
     println!("Found issues processed. Printing report");
-    printer.print_report(get_markdown_writer("report.md")?, &report, &context_loader)?;
+    printer.print_report(
+        get_markdown_writer(&output_file_path)?,
+        &report,
+        &context_loader,
+    )?;
 
-    println!("Report printed to ./report.md");
+    println!("Report printed to {}", output_file_path);
     Ok(())
 }
 
 fn get_markdown_writer(filename: &str) -> io::Result<File> {
+    let file_path = Path::new(filename);
+    if let Some(parent_dir) = file_path.parent() {
+        std::fs::create_dir_all(parent_dir)?;
+    }
     if Path::new(filename).exists() {
         remove_file(filename)?; // If file exists, delete it
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,10 @@ use tokei::{Config, LanguageType};
 struct Args {
     /// Foundry or Hardhat project root directory
     root: String,
+
+    /// Desired file path for the final report (will overwrite existing one)
+    #[arg(short, long, default_value = "report.md")]
+    output: String,
 }
 
 enum Framework {
@@ -25,6 +29,10 @@ enum Framework {
 
 fn main() {
     let args = Args::parse();
+
+    if !args.output.ends_with(".md") {
+        eprintln!("Warning: output file lacks the \".md\" extension in its filename.");
+    }
 
     // Detect the framework
     println!("Detecting framework...");
@@ -163,7 +171,7 @@ fn main() {
     context_loader.set_sloc_stats(languages[&LanguageType::Solidity].clone());
 
     // Load the context loader into the run function, which runs the detectors
-    run(context_loader).unwrap_or_else(|err| {
+    run(context_loader, args.output).unwrap_or_else(|err| {
         // Exit with a non-zero exit code
         eprintln!("Error running aderyn");
         eprintln!("{:?}", err);


### PR DESCRIPTION
Some use cases need the report to be written to a custom location. So I made this change. 
1. It doesn't break existing scripts (since it defaults to "report.md")
2. It generally makes it very convenient for people to integrate in their existing pipelines (maybe you want to write to a file attached as a docker volume, etc) 

```bash
Rust based Solidity AST analyzer

Usage: aderyn [OPTIONS] <ROOT>

Arguments:
  <ROOT>  Foundry or Hardhat project root directory

Options:
  -o, --output <OUTPUT>  Desired file path for the final report (will overwrite existing one) [default: report.md]
  -h, --help             Print help
  -V, --version          Print version
```
