### PR TITLE
Hardhat: handle multiple build info files

### DIFF
--- a/aderyn_core/src/framework/hardhat.rs
+++ b/aderyn_core/src/framework/hardhat.rs
@@ -43,8 +43,6 @@ pub fn load_hardhat(hardhat_root: &Path) -> Result<CumulativeHardhatOutput, Box<
     let cumulative_output_mutex = Mutex::new(cumulative_output);
 
     json_build_files.par_iter().for_each(|json_build_file| {
-        // print the found files
-        println!("Loading Hardhat build-info file: {:?}", json_build_file);
         let hardhat_output = read_hardhat_build_info_file(json_build_file).unwrap_or_else(|err| {
             // Exit with a non-zero exit code
             eprintln!("Error reading Hardhat build-info file");

--- a/aderyn_core/src/framework/hardhat.rs
+++ b/aderyn_core/src/framework/hardhat.rs
@@ -1,10 +1,16 @@
 use eyre::Result;
+use rayon::iter::*;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::error::Error;
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 
 use crate::ast::SourceUnit;
+
+pub struct CumulativeHardhatOutput {
+    pub output: HashMap<String, ContractSource>,
+}
 
 #[derive(Debug, Deserialize)]
 pub struct HardhatOutput {
@@ -16,12 +22,12 @@ pub struct Output {
     pub sources: HashMap<String, ContractSource>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct ContractSource {
     pub ast: SourceUnit,
 }
 
-pub fn load_hardhat(hardhat_root: &Path) -> Result<HardhatOutput, Box<dyn Error>> {
+pub fn load_hardhat(hardhat_root: &Path) -> Result<CumulativeHardhatOutput, Box<dyn Error>> {
     let config_path = hardhat_root.join("artifacts/build-info");
     let json_build_files = collect_json_files(config_path).unwrap_or_else(|err| {
         // Exit with a non-zero exit code
@@ -30,21 +36,35 @@ pub fn load_hardhat(hardhat_root: &Path) -> Result<HardhatOutput, Box<dyn Error>
         eprintln!("{:?}", err);
         std::process::exit(1);
     });
-    // print the found files
-    println!(
-        "Loading Hardhat build-info file: {:?}",
-        json_build_files.get(0).unwrap()
-    );
 
-    Ok(
-        read_hardhat_build_info_file(json_build_files.get(0).unwrap()).unwrap_or_else(|err| {
+    let mut cumulative_output = CumulativeHardhatOutput {
+        output: HashMap::new(),
+    };
+    let cumulative_output_mutex = Mutex::new(cumulative_output);
+
+    json_build_files.par_iter().for_each(|json_build_file| {
+        // print the found files
+        println!("Loading Hardhat build-info file: {:?}", json_build_file);
+        let hardhat_output = read_hardhat_build_info_file(json_build_file).unwrap_or_else(|err| {
             // Exit with a non-zero exit code
             eprintln!("Error reading Hardhat build-info file");
             // print err
             eprintln!("{:?}", err);
             std::process::exit(1);
-        }),
-    )
+        });
+        let mut cumulative_output = cumulative_output_mutex.lock().unwrap();
+        for (key, contract_source) in hardhat_output.output.sources.iter() {
+            if key.starts_with("contracts/") {
+                cumulative_output
+                    .output
+                    .insert(key.to_string(), contract_source.clone());
+            }
+        }
+    });
+    // Retrieve the cumulative_output after the parallel processing
+    cumulative_output = cumulative_output_mutex.into_inner().unwrap();
+
+    Ok(cumulative_output)
 }
 
 fn collect_json_files(dir: PathBuf) -> Result<Vec<PathBuf>, Box<dyn Error>> {

--- a/aderyn_driver/src/process_hardhat.rs
+++ b/aderyn_driver/src/process_hardhat.rs
@@ -16,31 +16,29 @@ pub fn with_project_root_at(root_path: &PathBuf) -> (String, ContextLoader) {
         eprintln!("{:?}", err);
         std::process::exit(1);
     });
-    for (key, contract_source) in hardhat_output.output.sources.iter() {
-        if key.starts_with("contracts/") {
-            let absolute_path_clone = contract_source.ast.absolute_path.clone();
-            let mut ast = contract_source.ast.clone();
-            match read_file_to_string(&root_path.join(Path::new(
-                &contract_source.ast.absolute_path.as_ref().unwrap(),
-            ))) {
-                Ok(content) => {
-                    ast.source = Some(content);
-                }
-                Err(err) => {
-                    eprintln!(
-                        "Error reading Solidity source file: {:?}",
-                        absolute_path_clone.unwrap()
-                    );
-                    eprintln!("{:?}", err);
-                }
+    for (_, contract_source) in hardhat_output.output.iter() {
+        let absolute_path_clone = contract_source.ast.absolute_path.clone();
+        let mut ast = contract_source.ast.clone();
+        match read_file_to_string(&root_path.join(Path::new(
+            &contract_source.ast.absolute_path.as_ref().unwrap(),
+        ))) {
+            Ok(content) => {
+                ast.source = Some(content);
             }
-
-            ast.accept(&mut context_loader).unwrap_or_else(|err| {
-                // Exit with a non-zero exit code
-                eprintln!("Error loading Hardhat AST into ContextLoader");
+            Err(err) => {
+                eprintln!(
+                    "Error reading Solidity source file: {:?}",
+                    absolute_path_clone.unwrap()
+                );
                 eprintln!("{:?}", err);
-            });
+            }
         }
+
+        ast.accept(&mut context_loader).unwrap_or_else(|err| {
+            // Exit with a non-zero exit code
+            eprintln!("Error loading Hardhat AST into ContextLoader");
+            eprintln!("{:?}", err);
+        });
     }
 
     (src_path, context_loader)


### PR DESCRIPTION
Fixes #49 .

It was originally assumed that a single build-info file is produced during a `hardhat compile`, but this is not always true. In cases where there are multiple, modern would often miss many solidity files. This reads all build-info files and loads all ASTs from them.