### PR TITLE
output root_path in json

### DIFF
--- a/aderyn_core/src/report/json_printer.rs
+++ b/aderyn_core/src/report/json_printer.rs
@@ -21,6 +21,7 @@ pub struct JsonContent {
     medium_issue: MediumIssues,
     low_issues: LowIssues,
     nc_issues: NcIssues,
+    root_path: String,
 }
 
 pub struct JsonPrinter;
@@ -43,7 +44,7 @@ impl ReportPrinter<()> for JsonPrinter {
         writer: W,
         report: &Report,
         loader: &ContextLoader,
-        _: PathBuf,
+        root_path: PathBuf,
         _: Option<String>,
     ) -> Result<()> {
         let content = JsonContent {
@@ -55,6 +56,7 @@ impl ReportPrinter<()> for JsonPrinter {
             medium_issue: report.medium_issues(),
             low_issues: report.low_issues(),
             nc_issues: report.nc_issues(),
+            root_path: String::from(root_path.as_path().to_str().unwrap_or_default()), // since it's not a very critical piece of info
         };
         let value = serde_json::to_value(content).unwrap();
         _ = serde_json::to_writer_pretty(writer, &value);


### PR DESCRIPTION
JSON output unlike MD is usually requested for other downstream applications to use it. And sometimes, it helps if these apps can actually go and read the contracts from the root - just the relative path alone which is currently captured wouldn't quite help.  One such app is [Aderyn AI](https://github.com/TilakMaddy/aderyn-ai) - shameless plug :P 

~~Minor Problem I see with the merge:
you can't have diff report.json report2.json in CI/CD .... (coz absolute paths will differ)~~

~~I guess we'd have to create a small python script that verifies json equality across all fields other than the root_path.. Good approach or not ?~~

Nope,changed my mind - infact I think that output sholdn't contain the root_path because then the user can be free to move the project folder around without worrying about anything breaking