### PR TITLE
introducing ContextBrowser as an abstraction on ContextLoader for detectors 

### DIFF
--- a/aderyn_core/src/context/browser/assignments.rs
+++ b/aderyn_core/src/context/browser/assignments.rs
@@ -1,0 +1,29 @@
+use eyre::Result;
+
+use crate::{
+    ast::{Assignment, FunctionDefinition},
+    visitor::ast_visitor::{ASTConstVisitor, Node},
+};
+
+pub struct Assignments {
+    pub assignments: Vec<Assignment>,
+}
+
+impl From<&FunctionDefinition> for Assignments {
+    fn from(function_definition: &FunctionDefinition) -> Assignments {
+        let mut assignments = Self {
+            assignments: vec![],
+        };
+        function_definition
+            .accept(&mut assignments)
+            .unwrap_or_default();
+        assignments
+    }
+}
+
+impl ASTConstVisitor for Assignments {
+    fn visit_assignment(&mut self, node: &Assignment) -> Result<bool> {
+        self.assignments.push(node.clone());
+        Ok(true)
+    }
+}

--- a/aderyn_core/src/context/browser/binary_checks.rs
+++ b/aderyn_core/src/context/browser/binary_checks.rs
@@ -1,0 +1,58 @@
+use eyre::Result;
+
+use crate::{
+    ast::{BinaryOperation, Expression, FunctionDefinition, NodeID},
+    visitor::ast_visitor::{ASTConstVisitor, Node},
+};
+
+pub struct BinaryChecks {
+    pub checks: Vec<BinaryCheckStatement>,
+}
+
+pub struct BinaryCheckStatement {
+    pub l_node_id: Option<NodeID>,
+    pub r_node_id: Option<NodeID>,
+    pub operator: String,
+}
+
+impl From<&FunctionDefinition> for BinaryChecks {
+    fn from(function_definition: &FunctionDefinition) -> BinaryChecks {
+        let mut binary_checks = Self { checks: vec![] };
+        function_definition
+            .accept(&mut binary_checks)
+            .unwrap_or_default();
+        binary_checks
+    }
+}
+
+impl ASTConstVisitor for BinaryChecks {
+    fn visit_binary_operation(&mut self, node: &BinaryOperation) -> Result<bool> {
+        let operator = node.operator.clone();
+
+        let l_node_id: Option<NodeID> = {
+            let l = node.left_expression.as_ref();
+            if let Expression::Identifier(left_identifier) = l {
+                Some(left_identifier.referenced_declaration)
+            } else {
+                None
+            }
+        };
+
+        let r_node_id: Option<NodeID> = {
+            let r = node.right_expression.as_ref();
+            if let Expression::Identifier(right_identifier) = r {
+                Some(right_identifier.referenced_declaration)
+            } else {
+                None
+            }
+        };
+
+        self.checks.push(BinaryCheckStatement {
+            l_node_id,
+            r_node_id,
+            operator,
+        });
+
+        Ok(true)
+    }
+}

--- a/aderyn_core/src/context/browser/mod.rs
+++ b/aderyn_core/src/context/browser/mod.rs
@@ -1,0 +1,63 @@
+use super::loader::ContextLoader;
+use crate::ast::NodeID;
+use rayon::iter::{FromParallelIterator, IntoParallelRefIterator, ParallelIterator};
+use std::collections::HashMap;
+
+mod assignments;
+mod binary_checks;
+mod node_locator;
+
+pub use assignments::Assignments;
+pub use binary_checks::{BinaryCheckStatement, BinaryChecks};
+
+pub struct ContextBrowser<'a> {
+    insights: HashMap<NodeID, SourceUnitInsight>,
+    loader: &'a ContextLoader,
+}
+
+impl<'a> ContextBrowser<'a> {
+    pub fn default_from(loader: &'a ContextLoader) -> Self {
+        ContextBrowser {
+            insights: HashMap::new(),
+            loader,
+        }
+    }
+
+    // populate insights
+    pub fn build_parallel(&mut self) {
+        let source_units = &self.loader.source_units;
+        let insights = source_units.par_iter().map(|src_unit| {
+            let id = src_unit.id;
+            let mut newline_char_indices = vec![];
+            if let Some(s) = src_unit.source.as_deref() {
+                for (idx, ch) in s.chars().enumerate() {
+                    if ch == '\n' {
+                        newline_char_indices.push(idx);
+                    }
+                }
+                (
+                    id,
+                    SourceUnitInsight {
+                        newline_char_indices,
+                        absent_source: false,
+                    },
+                )
+            } else {
+                (
+                    id,
+                    SourceUnitInsight {
+                        newline_char_indices,
+                        absent_source: true,
+                    },
+                )
+            }
+        });
+
+        self.insights = HashMap::from_par_iter(insights);
+    }
+}
+
+pub struct SourceUnitInsight {
+    newline_char_indices: Vec<usize>,
+    absent_source: bool,
+}

--- a/aderyn_core/src/context/browser/node_locator.rs
+++ b/aderyn_core/src/context/browser/node_locator.rs
@@ -1,0 +1,51 @@
+use super::{ContextBrowser, SourceUnitInsight};
+use crate::{ast::NodeID, context::loader::ASTNode};
+
+impl<'a> ContextBrowser<'a> {
+    pub fn get_node_sort_key(&self, node: &ASTNode) -> (String, usize) {
+        let source_unit = self.loader.get_source_unit_from_child_node(node).unwrap();
+        let absolute_path = source_unit.absolute_path.as_ref().unwrap().clone();
+
+        let node_id: NodeID = source_unit.id;
+        let insight = self.insights.get(&node_id).unwrap();
+
+        if insight.absent_source || node.src().is_none() {
+            return (absolute_path, 0);
+        }
+
+        let src = node.src().unwrap();
+        let ch_pos: usize = src
+            .split(":")
+            .take(1)
+            .map(|x| x.parse())
+            .next()
+            .unwrap()
+            .unwrap();
+
+        let line = self.get_source_line(insight, ch_pos);
+        return (absolute_path, line);
+    }
+
+    fn get_source_line(&self, insight: &SourceUnitInsight, ch_pos: usize) -> usize {
+        // edge cases for binary search
+        if insight.newline_char_indices.is_empty() || ch_pos < insight.newline_char_indices[0] {
+            return 1;
+        }
+
+        /*
+            Example:
+            newline_char_indices = [1, 5, 10, 24, 40, 50, 61]
+            |==> This will always be sorted in ascending order
+            |==> Given a character's position you can easily find
+            |==> its corresponding line with binary search.
+        */
+
+        let idx = insight
+            .newline_char_indices
+            .partition_point(|x| x < &ch_pos);
+
+        // idx is the number of newlines before ch_pos
+        // Adding one to it gives the line number of the current position
+        idx + 1
+    }
+}

--- a/aderyn_core/src/context/browser/node_locator.rs
+++ b/aderyn_core/src/context/browser/node_locator.rs
@@ -15,7 +15,7 @@ impl<'a> ContextBrowser<'a> {
 
         let src = node.src().unwrap();
         let ch_pos: usize = src
-            .split(":")
+            .split(':')
             .take(1)
             .map(|x| x.parse())
             .next()
@@ -23,7 +23,7 @@ impl<'a> ContextBrowser<'a> {
             .unwrap();
 
         let line = self.get_source_line(insight, ch_pos);
-        return (absolute_path, line);
+        (absolute_path, line)
     }
 
     fn get_source_line(&self, insight: &SourceUnitInsight, ch_pos: usize) -> usize {

--- a/aderyn_core/src/context/mod.rs
+++ b/aderyn_core/src/context/mod.rs
@@ -1,1 +1,2 @@
+pub mod browser;
 pub mod loader;

--- a/aderyn_core/src/detect/detector.rs
+++ b/aderyn_core/src/detect/detector.rs
@@ -1,5 +1,5 @@
 use crate::{
-    context::loader::ContextLoader,
+    context::{browser::ContextBrowser, loader::ContextLoader},
     detect::{
         high::{
             arbitrary_transfer_from::ArbitraryTransferFromDetector,
@@ -65,7 +65,11 @@ pub enum IssueSeverity {
 }
 
 pub trait Detector {
-    fn detect(&mut self, _loader: &ContextLoader) -> Result<bool, Box<dyn Error>> {
+    fn detect(
+        &mut self,
+        _loader: &ContextLoader,
+        __browser: &mut ContextBrowser,
+    ) -> Result<bool, Box<dyn Error>> {
         Ok(true)
     }
 

--- a/aderyn_core/src/detect/high/arbitrary_transfer_from.rs
+++ b/aderyn_core/src/detect/high/arbitrary_transfer_from.rs
@@ -3,6 +3,7 @@ use std::error::Error;
 
 use crate::ast::{Expression, FunctionCall, TypeName};
 
+use crate::context::browser::ContextBrowser;
 use crate::{
     context::loader::{ASTNode, ContextLoader},
     detect::detector::{Detector, IssueSeverity},
@@ -38,7 +39,11 @@ fn check_argument_validity(function_call: &FunctionCall) -> bool {
 }
 
 impl Detector for ArbitraryTransferFromDetector {
-    fn detect(&mut self, loader: &ContextLoader) -> Result<bool, Box<dyn Error>> {
+    fn detect(
+        &mut self,
+        loader: &ContextLoader,
+        browser: &mut ContextBrowser,
+    ) -> Result<bool, Box<dyn Error>> {
         let transfer_from_function_calls = loader.function_calls.keys().filter(|function_call| {
             if let Expression::MemberAccess(member_access) = &*function_call.expression {
                 if member_access.member_name == "transferFrom"
@@ -52,7 +57,7 @@ impl Detector for ArbitraryTransferFromDetector {
 
         for item in transfer_from_function_calls {
             self.found_instances.insert(
-                loader.get_node_sort_key(&ASTNode::FunctionCall(item.clone())),
+                browser.get_node_sort_key(&ASTNode::FunctionCall(item.clone())),
                 item.src.clone(),
             );
         }
@@ -79,9 +84,12 @@ impl Detector for ArbitraryTransferFromDetector {
 
 #[cfg(test)]
 mod arbitrary_transfer_from_tests {
-    use crate::detect::{
-        detector::{detector_test_helpers::load_contract, Detector},
-        high::arbitrary_transfer_from::ArbitraryTransferFromDetector,
+    use crate::{
+        context::browser::ContextBrowser,
+        detect::{
+            detector::{detector_test_helpers::load_contract, Detector},
+            high::arbitrary_transfer_from::ArbitraryTransferFromDetector,
+        },
     };
 
     #[test]
@@ -89,8 +97,14 @@ mod arbitrary_transfer_from_tests {
         let context_loader = load_contract(
             "../tests/contract-playground/out/ArbitraryTransferFrom.sol/ArbitraryTransferFrom.json",
         );
+
+        let mut context_browser = ContextBrowser::default_from(&context_loader);
+        context_browser.build_parallel();
+
         let mut detector = ArbitraryTransferFromDetector::default();
-        let found = detector.detect(&context_loader).unwrap();
+        let found = detector
+            .detect(&context_loader, &mut context_browser)
+            .unwrap();
         // assert that the detector found an issue
         assert!(found);
         // assert that the detector found the correct number of instances

--- a/aderyn_core/src/detect/high/delegate_call_in_loop.rs
+++ b/aderyn_core/src/detect/high/delegate_call_in_loop.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::error::Error;
 
+use crate::context::browser::ContextBrowser;
 use crate::visitor::ast_visitor::Node;
 use crate::{
     ast::MemberAccess,
@@ -29,7 +30,11 @@ impl ASTConstVisitor for DelegateCallInLoopDetector {
 }
 
 impl Detector for DelegateCallInLoopDetector {
-    fn detect(&mut self, loader: &ContextLoader) -> Result<bool, Box<dyn Error>> {
+    fn detect(
+        &mut self,
+        loader: &ContextLoader,
+        browser: &mut ContextBrowser,
+    ) -> Result<bool, Box<dyn Error>> {
         for for_statement in loader.for_statements.keys() {
             for_statement.accept(self)?;
         }
@@ -39,7 +44,7 @@ impl Detector for DelegateCallInLoopDetector {
         for member_access in self.found_member_access.clone().into_iter().flatten() {
             if let ASTNode::MemberAccess(member_access) = member_access {
                 self.found_instances.insert(
-                    loader.get_node_sort_key(&ASTNode::MemberAccess(member_access.clone())),
+                    browser.get_node_sort_key(&ASTNode::MemberAccess(member_access.clone())),
                     member_access.src.clone(),
                 );
             }
@@ -67,7 +72,10 @@ impl Detector for DelegateCallInLoopDetector {
 
 #[cfg(test)]
 mod delegate_call_in_loop_detector_tests {
-    use crate::detect::detector::{detector_test_helpers::load_contract, Detector};
+    use crate::{
+        context::browser::ContextBrowser,
+        detect::detector::{detector_test_helpers::load_contract, Detector},
+    };
 
     use super::DelegateCallInLoopDetector;
 
@@ -76,8 +84,12 @@ mod delegate_call_in_loop_detector_tests {
         let context_loader = load_contract(
             "../tests/contract-playground/out/ExtendedInheritance.sol/ExtendedInheritance.json",
         );
+        let mut context_browser = ContextBrowser::default_from(&context_loader);
+        context_browser.build_parallel();
         let mut detector = DelegateCallInLoopDetector::default();
-        let found = detector.detect(&context_loader).unwrap();
+        let found = detector
+            .detect(&context_loader, &mut context_browser)
+            .unwrap();
         // assert that the detector found a delegate call in a loop
         assert!(found);
         // assert that the detector found the correct number of instances (1)

--- a/aderyn_core/src/detect/low/deprecated_oz_functions.rs
+++ b/aderyn_core/src/detect/low/deprecated_oz_functions.rs
@@ -1,7 +1,10 @@
 use std::{collections::BTreeMap, error::Error};
 
 use crate::{
-    context::loader::{ASTNode, ContextLoader},
+    context::{
+        browser::ContextBrowser,
+        loader::{ASTNode, ContextLoader},
+    },
     detect::detector::{Detector, IssueSeverity},
 };
 use eyre::Result;
@@ -13,7 +16,11 @@ pub struct DeprecatedOZFunctionsDetector {
 }
 
 impl Detector for DeprecatedOZFunctionsDetector {
-    fn detect(&mut self, loader: &ContextLoader) -> Result<bool, Box<dyn Error>> {
+    fn detect(
+        &mut self,
+        loader: &ContextLoader,
+        browser: &mut ContextBrowser,
+    ) -> Result<bool, Box<dyn Error>> {
         for identifier in loader.identifiers.keys() {
             // if source_unit has any ImportDirectives with absolute_path containing "openzeppelin"
             // call identifier.accept(self)
@@ -30,7 +37,7 @@ impl Detector for DeprecatedOZFunctionsDetector {
             }) && identifier.name == "_setupRole"
             {
                 self.found_instances.insert(
-                    loader.get_node_sort_key(&ASTNode::Identifier(identifier.clone())),
+                    browser.get_node_sort_key(&ASTNode::Identifier(identifier.clone())),
                     identifier.src.clone(),
                 );
             }
@@ -50,7 +57,7 @@ impl Detector for DeprecatedOZFunctionsDetector {
             }) && member_access.member_name == "safeApprove"
             {
                 self.found_instances.insert(
-                    loader.get_node_sort_key(&ASTNode::MemberAccess(member_access.clone())),
+                    browser.get_node_sort_key(&ASTNode::MemberAccess(member_access.clone())),
                     member_access.src.clone(),
                 );
             }
@@ -77,7 +84,10 @@ impl Detector for DeprecatedOZFunctionsDetector {
 
 #[cfg(test)]
 mod deprecated_oz_functions_tests {
-    use crate::detect::detector::{detector_test_helpers::load_contract, Detector};
+    use crate::{
+        context::browser::ContextBrowser,
+        detect::detector::{detector_test_helpers::load_contract, Detector},
+    };
 
     use super::DeprecatedOZFunctionsDetector;
 
@@ -86,8 +96,14 @@ mod deprecated_oz_functions_tests {
         let context_loader = load_contract(
             "../tests/contract-playground/out/DeprecatedOZFunctions.sol/DeprecatedOZFunctions.json",
         );
+
+        let mut context_browser = ContextBrowser::default_from(&context_loader);
+        context_browser.build_parallel();
+
         let mut detector = DeprecatedOZFunctionsDetector::default();
-        let found = detector.detect(&context_loader).unwrap();
+        let found = detector
+            .detect(&context_loader, &mut context_browser)
+            .unwrap();
         // assert that the detector found an abi encode packed
         assert!(found);
         // assert that the detector found the correct number of instances

--- a/aderyn_core/src/detect/low/different_storage_conditionals.rs
+++ b/aderyn_core/src/detect/low/different_storage_conditionals.rs
@@ -5,7 +5,10 @@ use std::{
 
 use crate::{
     ast::{BinaryOperation, Expression, VariableDeclaration},
-    context::loader::{ASTNode, ContextLoader},
+    context::{
+        browser::ContextBrowser,
+        loader::{ASTNode, ContextLoader},
+    },
     detect::detector::{Detector, IssueSeverity},
 };
 use eyre::Result;
@@ -17,7 +20,11 @@ pub struct DifferentStorageConditionalDetector {
 }
 
 impl Detector for DifferentStorageConditionalDetector {
-    fn detect(&mut self, loader: &ContextLoader) -> Result<bool, Box<dyn Error>> {
+    fn detect(
+        &mut self,
+        loader: &ContextLoader,
+        browser: &mut ContextBrowser,
+    ) -> Result<bool, Box<dyn Error>> {
         // Step 1: Get all state variable declarations
         let state_variables: Vec<&VariableDeclaration> = loader
             .variable_declarations
@@ -93,12 +100,12 @@ impl Detector for DifferentStorageConditionalDetector {
 
                     if !is_consistent_or_mirror {
                         self.found_instances.insert(
-                            loader.get_node_sort_key(&ASTNode::BinaryOperation((*op).clone())),
+                            browser.get_node_sort_key(&ASTNode::BinaryOperation((*op).clone())),
                             op.src.clone(),
                         );
                         if !first_added {
                             self.found_instances.insert(
-                                loader.get_node_sort_key(&ASTNode::BinaryOperation(
+                                browser.get_node_sort_key(&ASTNode::BinaryOperation(
                                     (*first_op).clone(),
                                 )),
                                 first_op.src.clone(),
@@ -133,7 +140,10 @@ impl Detector for DifferentStorageConditionalDetector {
 
 #[cfg(test)]
 mod different_storage_conditionals_tests {
-    use crate::detect::detector::{detector_test_helpers::load_contract, Detector};
+    use crate::{
+        context::browser::ContextBrowser,
+        detect::detector::{detector_test_helpers::load_contract, Detector},
+    };
 
     use super::DifferentStorageConditionalDetector;
 
@@ -143,7 +153,12 @@ mod different_storage_conditionals_tests {
             "../tests/contract-playground/out/StorageConditionals.sol/StorageConditionals.json",
         );
         let mut detector = DifferentStorageConditionalDetector::default();
-        let found = detector.detect(&context_loader).unwrap();
+        let mut context_browser = ContextBrowser::default_from(&context_loader);
+        context_browser.build_parallel();
+
+        let found = detector
+            .detect(&context_loader, &mut context_browser)
+            .unwrap();
 
         // assert found
         assert!(found);

--- a/aderyn_core/src/detect/low/ecrecover.rs
+++ b/aderyn_core/src/detect/low/ecrecover.rs
@@ -1,7 +1,10 @@
 use std::{collections::BTreeMap, error::Error};
 
 use crate::{
-    context::loader::{ASTNode, ContextLoader},
+    context::{
+        browser::ContextBrowser,
+        loader::{ASTNode, ContextLoader},
+    },
     detect::detector::{Detector, IssueSeverity},
 };
 use eyre::Result;
@@ -13,11 +16,15 @@ pub struct EcrecoverDetector {
 }
 
 impl Detector for EcrecoverDetector {
-    fn detect(&mut self, loader: &ContextLoader) -> Result<bool, Box<dyn Error>> {
+    fn detect(
+        &mut self,
+        loader: &ContextLoader,
+        browser: &mut ContextBrowser,
+    ) -> Result<bool, Box<dyn Error>> {
         for identifier in loader.identifiers.keys() {
             if identifier.name == "ecrecover" {
                 self.found_instances.insert(
-                    loader.get_node_sort_key(&ASTNode::Identifier(identifier.clone())),
+                    browser.get_node_sort_key(&ASTNode::Identifier(identifier.clone())),
                     identifier.src.clone(),
                 );
             }
@@ -52,7 +59,10 @@ impl Detector for EcrecoverDetector {
 #[cfg(test)]
 mod ecrecover_tests {
 
-    use crate::detect::detector::{detector_test_helpers::load_contract, Detector};
+    use crate::{
+        context::browser::ContextBrowser,
+        detect::detector::{detector_test_helpers::load_contract, Detector},
+    };
 
     use super::EcrecoverDetector;
 
@@ -61,8 +71,12 @@ mod ecrecover_tests {
         let context_loader = load_contract(
             "../tests/contract-playground/out/ExtendedInheritance.sol/ExtendedInheritance.json",
         );
+        let mut context_browser = ContextBrowser::default_from(&context_loader);
+        context_browser.build_parallel();
         let mut detector = EcrecoverDetector::default();
-        let found = detector.detect(&context_loader).unwrap();
+        let found = detector
+            .detect(&context_loader, &mut context_browser)
+            .unwrap();
         // assert that the detector found an ecrecover
         assert!(found);
         // assert that the detector found the correct ecrecover

--- a/aderyn_core/src/detect/low/push_0_opcode.rs
+++ b/aderyn_core/src/detect/low/push_0_opcode.rs
@@ -1,7 +1,10 @@
 use std::{collections::BTreeMap, error::Error};
 
 use crate::{
-    context::loader::{ASTNode, ContextLoader},
+    context::{
+        browser::ContextBrowser,
+        loader::{ASTNode, ContextLoader},
+    },
     detect::detector::{Detector, IssueSeverity},
 };
 use eyre::Result;
@@ -51,7 +54,11 @@ fn version_req_allows_above_0_8_19(version_req: &VersionReq) -> bool {
 }
 
 impl Detector for PushZeroOpcodeDetector {
-    fn detect(&mut self, loader: &ContextLoader) -> Result<bool, Box<dyn Error>> {
+    fn detect(
+        &mut self,
+        loader: &ContextLoader,
+        browser: &mut ContextBrowser,
+    ) -> Result<bool, Box<dyn Error>> {
         for pragma_directive in loader.pragma_directives.keys() {
             let mut version_string = String::new();
 
@@ -70,7 +77,7 @@ impl Detector for PushZeroOpcodeDetector {
             let req = VersionReq::parse(&version_string)?;
             if version_req_allows_above_0_8_19(&req) {
                 self.found_instances.insert(
-                    loader.get_node_sort_key(&ASTNode::PragmaDirective(pragma_directive.clone())),
+                    browser.get_node_sort_key(&ASTNode::PragmaDirective(pragma_directive.clone())),
                     pragma_directive.src.clone(),
                 );
             }
@@ -98,15 +105,22 @@ impl Detector for PushZeroOpcodeDetector {
 
 #[cfg(test)]
 mod unspecific_solidity_pragma_tests {
-    use crate::detect::detector::{detector_test_helpers::load_contract, Detector};
+    use crate::{
+        context::browser::ContextBrowser,
+        detect::detector::{detector_test_helpers::load_contract, Detector},
+    };
 
     #[test]
     fn test_push_0_opcode_detector_on_0_8_20() {
         let context_loader = load_contract(
             "../tests/contract-playground/out/ExtendedInheritance.sol/ExtendedInheritance.json",
         );
+        let mut context_browser = ContextBrowser::default_from(&context_loader);
+        context_browser.build_parallel();
         let mut detector = super::PushZeroOpcodeDetector::default();
-        let found = detector.detect(&context_loader).unwrap();
+        let found = detector
+            .detect(&context_loader, &mut context_browser)
+            .unwrap();
         // assert that it found something
         assert!(found);
         // assert that the number of instances is correct
@@ -134,8 +148,13 @@ mod unspecific_solidity_pragma_tests {
     fn test_push_0_opcode_detector_on_range() {
         let context_loader =
             load_contract("../tests/contract-playground/out/CrazyPragma.sol/CrazyPragma.json");
+        let mut context_browser = ContextBrowser::default_from(&context_loader);
+        context_browser.build_parallel();
+
         let mut detector = super::PushZeroOpcodeDetector::default();
-        let found = detector.detect(&context_loader).unwrap();
+        let found = detector
+            .detect(&context_loader, &mut context_browser)
+            .unwrap();
         // assert that it found something
         assert!(found);
         // assert that the number of instances is correct
@@ -164,8 +183,13 @@ mod unspecific_solidity_pragma_tests {
         let context_loader = load_contract(
             "../tests/contract-playground/out/ArbitraryTransferFrom.sol/ArbitraryTransferFrom.json",
         );
+        let mut context_browser = ContextBrowser::default_from(&context_loader);
+        context_browser.build_parallel();
+
         let mut detector = super::PushZeroOpcodeDetector::default();
-        let found = detector.detect(&context_loader).unwrap();
+        let found = detector
+            .detect(&context_loader, &mut context_browser)
+            .unwrap();
         // assert that it found something
         assert!(!found);
         // assert that the number of instances is correct
@@ -176,8 +200,14 @@ mod unspecific_solidity_pragma_tests {
     fn test_push_0_opcode_detector_on_caret_0_8_13() {
         let context_loader =
             load_contract("../tests/contract-playground/out/Counter.sol/Counter.0.8.21.json");
+
+        let mut context_browser = ContextBrowser::default_from(&context_loader);
+        context_browser.build_parallel();
+
         let mut detector = super::PushZeroOpcodeDetector::default();
-        let found = detector.detect(&context_loader).unwrap();
+        let found = detector
+            .detect(&context_loader, &mut context_browser)
+            .unwrap();
         // assert that it found something
         assert!(found);
         // assert that the number of instances is correct
@@ -189,8 +219,12 @@ mod unspecific_solidity_pragma_tests {
         let context_loader = load_contract(
             "../tests/contract-playground/out/IContractInheritance.sol/IContractInheritance.0.8.21.json",
         );
+        let mut context_browser = ContextBrowser::default_from(&context_loader);
+        context_browser.build_parallel();
         let mut detector = super::PushZeroOpcodeDetector::default();
-        let found = detector.detect(&context_loader).unwrap();
+        let found = detector
+            .detect(&context_loader, &mut context_browser)
+            .unwrap();
         // assert that it found something
         assert!(found);
         // assert that the number of instances is correct

--- a/aderyn_core/src/detect/low/unsafe_erc20_functions.rs
+++ b/aderyn_core/src/detect/low/unsafe_erc20_functions.rs
@@ -1,7 +1,10 @@
 use std::{collections::BTreeMap, error::Error};
 
 use crate::{
-    context::loader::{ASTNode, ContextLoader},
+    context::{
+        browser::ContextBrowser,
+        loader::{ASTNode, ContextLoader},
+    },
     detect::detector::{Detector, IssueSeverity},
 };
 use eyre::Result;
@@ -13,14 +16,18 @@ pub struct UnsafeERC20FunctionsDetector {
 }
 
 impl Detector for UnsafeERC20FunctionsDetector {
-    fn detect(&mut self, loader: &ContextLoader) -> Result<bool, Box<dyn Error>> {
+    fn detect(
+        &mut self,
+        loader: &ContextLoader,
+        browser: &mut ContextBrowser,
+    ) -> Result<bool, Box<dyn Error>> {
         for member_access in loader.member_accesses.keys() {
             if member_access.member_name == "transferFrom"
                 || member_access.member_name == "approve"
                 || member_access.member_name == "transfer"
             {
                 self.found_instances.insert(
-                    loader.get_node_sort_key(&ASTNode::MemberAccess(member_access.clone())),
+                    browser.get_node_sort_key(&ASTNode::MemberAccess(member_access.clone())),
                     member_access.src.clone(),
                 );
             }
@@ -47,7 +54,10 @@ impl Detector for UnsafeERC20FunctionsDetector {
 
 #[cfg(test)]
 mod unsafe_erc20_functions_tests {
-    use crate::detect::detector::{detector_test_helpers::load_contract, Detector};
+    use crate::{
+        context::browser::ContextBrowser,
+        detect::detector::{detector_test_helpers::load_contract, Detector},
+    };
 
     use super::UnsafeERC20FunctionsDetector;
 
@@ -56,8 +66,12 @@ mod unsafe_erc20_functions_tests {
         let context_loader = load_contract(
             "../tests/contract-playground/out/DeprecatedOZFunctions.sol/DeprecatedOZFunctions.json",
         );
+        let mut context_browser = ContextBrowser::default_from(&context_loader);
+        context_browser.build_parallel();
         let mut detector = UnsafeERC20FunctionsDetector::default();
-        let found = detector.detect(&context_loader).unwrap();
+        let found = detector
+            .detect(&context_loader, &mut context_browser)
+            .unwrap();
         // assert that the detector found an abi encode packed
         assert!(found);
         // assert that the detector found the correct abi encode packed

--- a/aderyn_core/src/detect/low/unspecific_solidity_pragma.rs
+++ b/aderyn_core/src/detect/low/unspecific_solidity_pragma.rs
@@ -1,7 +1,10 @@
 use std::{collections::BTreeMap, error::Error};
 
 use crate::{
-    context::loader::{ASTNode, ContextLoader},
+    context::{
+        browser::ContextBrowser,
+        loader::{ASTNode, ContextLoader},
+    },
     detect::detector::{Detector, IssueSeverity},
 };
 use eyre::Result;
@@ -13,12 +16,16 @@ pub struct UnspecificSolidityPragmaDetector {
 }
 
 impl Detector for UnspecificSolidityPragmaDetector {
-    fn detect(&mut self, loader: &ContextLoader) -> Result<bool, Box<dyn Error>> {
+    fn detect(
+        &mut self,
+        loader: &ContextLoader,
+        browser: &mut ContextBrowser,
+    ) -> Result<bool, Box<dyn Error>> {
         for pragma_directive in loader.pragma_directives.keys() {
             for literal in &pragma_directive.literals {
                 if literal.contains('^') || literal.contains('>') {
                     self.found_instances.insert(
-                        loader
+                        browser
                             .get_node_sort_key(&ASTNode::PragmaDirective(pragma_directive.clone())),
                         pragma_directive.src.clone(),
                     );
@@ -48,9 +55,12 @@ impl Detector for UnspecificSolidityPragmaDetector {
 
 #[cfg(test)]
 mod unspecific_solidity_pragma_tests {
-    use crate::detect::{
-        detector::{detector_test_helpers::load_contract, Detector},
-        low::unspecific_solidity_pragma::UnspecificSolidityPragmaDetector,
+    use crate::{
+        context::browser::ContextBrowser,
+        detect::{
+            detector::{detector_test_helpers::load_contract, Detector},
+            low::unspecific_solidity_pragma::UnspecificSolidityPragmaDetector,
+        },
     };
 
     #[test]
@@ -58,8 +68,12 @@ mod unspecific_solidity_pragma_tests {
         let context_loader = load_contract(
             "../tests/contract-playground/out/IContractInheritance.sol/IContractInheritance.0.8.21.json",
         );
+        let mut context_browser = ContextBrowser::default_from(&context_loader);
+        context_browser.build_parallel();
         let mut detector = UnspecificSolidityPragmaDetector::default();
-        let found = detector.detect(&context_loader).unwrap();
+        let found = detector
+            .detect(&context_loader, &mut context_browser)
+            .unwrap();
         // assert that the detector found an abi encode packed
         assert!(found);
         // assert that the detector found the correct abi encode packed

--- a/aderyn_core/src/detect/medium/solmate_safe_transfer_lib.rs
+++ b/aderyn_core/src/detect/medium/solmate_safe_transfer_lib.rs
@@ -1,7 +1,10 @@
 use std::{collections::BTreeMap, error::Error};
 
 use crate::{
-    context::loader::{ASTNode, ContextLoader},
+    context::{
+        browser::ContextBrowser,
+        loader::{ASTNode, ContextLoader},
+    },
     detect::detector::{Detector, IssueSeverity},
 };
 use eyre::Result;
@@ -13,7 +16,11 @@ pub struct SolmateSafeTransferLibDetector {
 }
 
 impl Detector for SolmateSafeTransferLibDetector {
-    fn detect(&mut self, loader: &ContextLoader) -> Result<bool, Box<dyn Error>> {
+    fn detect(
+        &mut self,
+        loader: &ContextLoader,
+        browser: &mut ContextBrowser,
+    ) -> Result<bool, Box<dyn Error>> {
         for import_directive in loader.import_directives.keys() {
             // If the import directive absolute_path contains the strings "solmate" and "SafeTransferLib", flip the found_solmate_import flag to true
             if import_directive
@@ -28,7 +35,7 @@ impl Detector for SolmateSafeTransferLibDetector {
                     .contains("SafeTransferLib")
             {
                 self.found_instances.insert(
-                    loader.get_node_sort_key(&ASTNode::ImportDirective(import_directive.clone())),
+                    browser.get_node_sort_key(&ASTNode::ImportDirective(import_directive.clone())),
                     import_directive.src.clone(),
                 );
             }
@@ -56,17 +63,25 @@ impl Detector for SolmateSafeTransferLibDetector {
 
 #[cfg(test)]
 mod solmate_safe_transfer_lib_tests {
-    use crate::detect::{
-        detector::{detector_test_helpers::load_contract, Detector},
-        medium::solmate_safe_transfer_lib::SolmateSafeTransferLibDetector,
+    use crate::{
+        context::browser::ContextBrowser,
+        detect::{
+            detector::{detector_test_helpers::load_contract, Detector},
+            medium::solmate_safe_transfer_lib::SolmateSafeTransferLibDetector,
+        },
     };
 
     #[test]
     fn test_solmate_safe_transfer_lib() {
         let context_loader =
             load_contract("../tests/contract-playground/out/T11sTranferer.sol/T11sTranferer.json");
+
+        let mut context_browser = ContextBrowser::default_from(&context_loader);
+        context_browser.build_parallel();
         let mut detector = SolmateSafeTransferLibDetector::default();
-        let found = detector.detect(&context_loader).unwrap();
+        let found = detector
+            .detect(&context_loader, &mut context_browser)
+            .unwrap();
         // assert that the detector found
         assert!(found);
         // assert that the detector found the correct number of instances (1)
@@ -97,8 +112,12 @@ mod solmate_safe_transfer_lib_tests {
         let context_loader = load_contract(
             "../tests/contract-playground/out/ArbitraryTransferFrom.sol/ArbitraryTransferFrom.json",
         );
+        let mut context_browser = ContextBrowser::default_from(&context_loader);
+        context_browser.build_parallel();
         let mut detector = SolmateSafeTransferLibDetector::default();
-        let found = detector.detect(&context_loader).unwrap();
+        let found = detector
+            .detect(&context_loader, &mut context_browser)
+            .unwrap();
         // assert that the detector found
         assert!(!found);
         // assert that the detector found the correct number of instances

--- a/aderyn_core/src/detect/nc/constants_instead_of_literals.rs
+++ b/aderyn_core/src/detect/nc/constants_instead_of_literals.rs
@@ -2,7 +2,10 @@ use std::{collections::BTreeMap, error::Error};
 
 use crate::{
     ast::{Literal, LiteralKind},
-    context::loader::{ASTNode, ContextLoader},
+    context::{
+        browser::ContextBrowser,
+        loader::{ASTNode, ContextLoader},
+    },
     detect::detector::{Detector, IssueSeverity},
     visitor::ast_visitor::{ASTConstVisitor, Node},
 };
@@ -30,7 +33,11 @@ impl ASTConstVisitor for ConstantsInsteadOfLiteralsDetector {
 }
 
 impl Detector for ConstantsInsteadOfLiteralsDetector {
-    fn detect(&mut self, loader: &ContextLoader) -> Result<bool, Box<dyn Error>> {
+    fn detect(
+        &mut self,
+        loader: &ContextLoader,
+        browser: &mut ContextBrowser,
+    ) -> Result<bool, Box<dyn Error>> {
         // get all function definitions.
         // for each function definition, find all Literal types
         // if the literal type is either a Number, HexString or Address, then add it to the list of found literals
@@ -40,7 +47,7 @@ impl Detector for ConstantsInsteadOfLiteralsDetector {
         for literal in self.found_literals.clone().into_iter().flatten() {
             if let ASTNode::Literal(literal) = literal {
                 self.found_instances.insert(
-                    loader.get_node_sort_key(&ASTNode::Literal(literal.clone())),
+                    browser.get_node_sort_key(&ASTNode::Literal(literal.clone())),
                     literal.src.clone(),
                 );
             }
@@ -68,7 +75,10 @@ impl Detector for ConstantsInsteadOfLiteralsDetector {
 
 #[cfg(test)]
 mod constants_instead_of_literals_tests {
-    use crate::detect::detector::{detector_test_helpers::load_contract, Detector};
+    use crate::{
+        context::browser::ContextBrowser,
+        detect::detector::{detector_test_helpers::load_contract, Detector},
+    };
 
     use super::ConstantsInsteadOfLiteralsDetector;
 
@@ -76,9 +86,14 @@ mod constants_instead_of_literals_tests {
     fn test_constants_instead_of_literals() {
         let context_loader =
             load_contract("../tests/contract-playground/out/Counter.sol/Counter.0.8.21.json");
+        let mut context_browser = ContextBrowser::default_from(&context_loader);
+        context_browser.build_parallel();
+
         let mut detector = ConstantsInsteadOfLiteralsDetector::default();
         // assert that the detector finds the public function
-        let found = detector.detect(&context_loader).unwrap();
+        let found = detector
+            .detect(&context_loader, &mut context_browser)
+            .unwrap();
         assert!(found);
         // assert that the detector finds the correct number of instances
         assert_eq!(detector.instances().len(), 1);

--- a/aderyn_core/src/detect/nc/non_reentrant_before_others.rs
+++ b/aderyn_core/src/detect/nc/non_reentrant_before_others.rs
@@ -1,7 +1,10 @@
 use std::{collections::BTreeMap, error::Error};
 
 use crate::{
-    context::loader::{ASTNode, ContextLoader},
+    context::{
+        browser::ContextBrowser,
+        loader::{ASTNode, ContextLoader},
+    },
     detect::detector::{Detector, IssueSeverity},
 };
 use eyre::Result;
@@ -13,14 +16,18 @@ pub struct NonReentrantBeforeOthersDetector {
 }
 
 impl Detector for NonReentrantBeforeOthersDetector {
-    fn detect(&mut self, loader: &ContextLoader) -> Result<bool, Box<dyn Error>> {
+    fn detect(
+        &mut self,
+        loader: &ContextLoader,
+        browser: &mut ContextBrowser,
+    ) -> Result<bool, Box<dyn Error>> {
         let function_definitions = loader.function_definitions.keys();
         for definition in function_definitions {
             if definition.modifiers.len() > 1 {
                 for (index, modifier) in definition.modifiers.iter().enumerate() {
                     if modifier.modifier_name.name == "nonReentrant" && index != 0 {
                         self.found_instances.insert(
-                            loader
+                            browser
                                 .get_node_sort_key(&ASTNode::ModifierInvocation(modifier.clone())),
                             modifier.src.clone(),
                         );
@@ -50,17 +57,25 @@ impl Detector for NonReentrantBeforeOthersDetector {
 
 #[cfg(test)]
 mod non_reentrant_before_others_tests {
-    use crate::detect::{
-        detector::{detector_test_helpers::load_contract, Detector},
-        nc::non_reentrant_before_others::NonReentrantBeforeOthersDetector,
+    use crate::{
+        context::browser::ContextBrowser,
+        detect::{
+            detector::{detector_test_helpers::load_contract, Detector},
+            nc::non_reentrant_before_others::NonReentrantBeforeOthersDetector,
+        },
     };
 
     #[test]
     fn test_non_reentrant_before_others() {
         let context_loader =
             load_contract("../tests/contract-playground/out/AdminContract.sol/AdminContract.json");
+        let mut context_browser = ContextBrowser::default_from(&context_loader);
+        context_browser.build_parallel();
+
         let mut detector = NonReentrantBeforeOthersDetector::default();
-        let found = detector.detect(&context_loader).unwrap();
+        let found = detector
+            .detect(&context_loader, &mut context_browser)
+            .unwrap();
         // assert that the detector found something
         assert!(found);
         // assert that the detector found the correct number

--- a/aderyn_core/src/detect/nc/require_with_string.rs
+++ b/aderyn_core/src/detect/nc/require_with_string.rs
@@ -1,7 +1,10 @@
 use std::{collections::BTreeMap, error::Error};
 
 use crate::{
-    context::loader::{ASTNode, ContextLoader},
+    context::{
+        browser::ContextBrowser,
+        loader::{ASTNode, ContextLoader},
+    },
     detect::detector::{Detector, IssueSeverity},
 };
 use eyre::Result;
@@ -13,7 +16,11 @@ pub struct RequireWithStringDetector {
 }
 
 impl Detector for RequireWithStringDetector {
-    fn detect(&mut self, loader: &ContextLoader) -> Result<bool, Box<dyn Error>> {
+    fn detect(
+        &mut self,
+        loader: &ContextLoader,
+        browser: &mut ContextBrowser,
+    ) -> Result<bool, Box<dyn Error>> {
         // Collect all require statements without a string literal.
         let requires_and_reverts = loader
             .identifiers
@@ -25,7 +32,7 @@ impl Detector for RequireWithStringDetector {
                 || (id.name == "require" && id.argument_types.as_ref().unwrap().len() == 1)
             {
                 self.found_instances.insert(
-                    loader.get_node_sort_key(&ASTNode::Identifier(id.clone())),
+                    browser.get_node_sort_key(&ASTNode::Identifier(id.clone())),
                     id.src.clone(),
                 );
             }
@@ -53,7 +60,10 @@ impl Detector for RequireWithStringDetector {
 
 #[cfg(test)]
 mod require_with_string_tests {
-    use crate::detect::detector::{detector_test_helpers::load_contract, Detector};
+    use crate::{
+        context::browser::ContextBrowser,
+        detect::detector::{detector_test_helpers::load_contract, Detector},
+    };
 
     use super::RequireWithStringDetector;
 
@@ -62,9 +72,13 @@ mod require_with_string_tests {
         let context_loader = load_contract(
             "../tests/contract-playground/out/DeprecatedOZFunctions.sol/DeprecatedOZFunctions.json",
         );
+        let mut context_browser = ContextBrowser::default_from(&context_loader);
+        context_browser.build_parallel();
         let mut detector = RequireWithStringDetector::default();
         // assert that the detector finds something
-        let found = detector.detect(&context_loader).unwrap();
+        let found = detector
+            .detect(&context_loader, &mut context_browser)
+            .unwrap();
         assert!(found);
         // assert that the detector returns the correct number of instances
         assert_eq!(detector.instances().len(), 2);

--- a/aderyn_core/src/detect/nc/unindexed_events.rs
+++ b/aderyn_core/src/detect/nc/unindexed_events.rs
@@ -1,7 +1,10 @@
 use std::{collections::BTreeMap, error::Error};
 
 use crate::{
-    context::loader::{ASTNode, ContextLoader},
+    context::{
+        browser::ContextBrowser,
+        loader::{ASTNode, ContextLoader},
+    },
     detect::detector::{Detector, IssueSeverity},
 };
 use eyre::Result;
@@ -13,7 +16,11 @@ pub struct UnindexedEventsDetector {
 }
 
 impl Detector for UnindexedEventsDetector {
-    fn detect(&mut self, loader: &ContextLoader) -> Result<bool, Box<dyn Error>> {
+    fn detect(
+        &mut self,
+        loader: &ContextLoader,
+        browser: &mut ContextBrowser,
+    ) -> Result<bool, Box<dyn Error>> {
         // for each event definition, check if it has any indexed parameters
         // if it does not, then add it to the list of found unindexed events
         for event_definition in loader.event_definitions.keys() {
@@ -30,7 +37,7 @@ impl Detector for UnindexedEventsDetector {
 
             if non_indexed && indexed_count < 3 {
                 self.found_instances.insert(
-                    loader
+                    browser
                         .get_node_sort_key(&ASTNode::EventDefinition((*event_definition).clone())),
                     event_definition.src.clone(),
                 );
@@ -60,7 +67,10 @@ impl Detector for UnindexedEventsDetector {
 
 #[cfg(test)]
 mod unindexed_event_tests {
-    use crate::detect::detector::{detector_test_helpers::load_contract, Detector};
+    use crate::{
+        context::browser::ContextBrowser,
+        detect::detector::{detector_test_helpers::load_contract, Detector},
+    };
 
     use super::UnindexedEventsDetector;
 
@@ -69,9 +79,13 @@ mod unindexed_event_tests {
         let context_loader = load_contract(
             "../tests/contract-playground/out/ExtendedInheritance.sol/ExtendedInheritance.json",
         );
+        let mut context_browser = ContextBrowser::default_from(&context_loader);
+        context_browser.build_parallel();
         let mut detector = UnindexedEventsDetector::default();
         // assert that the detector finds the public function
-        let found = detector.detect(&context_loader).unwrap();
+        let found = detector
+            .detect(&context_loader, &mut context_browser)
+            .unwrap();
         assert!(found);
         // assert that the detector finds the correct number of unindexed events
         assert_eq!(detector.instances().len(), 1);

--- a/aderyn_core/src/detect/nc/zero_address_check.rs
+++ b/aderyn_core/src/detect/nc/zero_address_check.rs
@@ -88,17 +88,17 @@ impl Detector for ZeroAddressCheckDetector {
             let assignments = assigments
                 .assignments
                 .iter()
-                .filter_map(|x| {
+                .filter(|x| {
                     let left_hand_side = x.left_hand_side.as_ref();
                     if let Expression::Identifier(left_identifier) = left_hand_side {
                         if self
                             .mutable_address_state_variables
                             .contains_key(&left_identifier.referenced_declaration)
                         {
-                            return Some(x);
+                            return true;
                         }
                     }
-                    None
+                    false
                 })
                 .filter_map(|x| {
                     let right_hand_side = x.right_hand_side.as_ref();
@@ -121,7 +121,7 @@ impl Detector for ZeroAddressCheckDetector {
             // if there are assignments to mutable address state variables that are not present
             // in the binary_checks_against_zero_address, add the assignment to the found_no_zero_address_check
             for (key, value) in &assignments_to_mutable_address_state_variables {
-                if !binary_checks_against_zero_address.contains(&key) {
+                if !binary_checks_against_zero_address.contains(key) {
                     self.found_instances.insert(
                         browser.get_node_sort_key(&ASTNode::Assignment(value.clone())),
                         value.src.clone(),

--- a/aderyn_core/src/detect/nc/zero_address_check.rs
+++ b/aderyn_core/src/detect/nc/zero_address_check.rs
@@ -1,90 +1,33 @@
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, HashSet},
     error::Error,
 };
 
 use crate::{
-    ast::{Assignment, BinaryOperation, Expression, Mutability, VariableDeclaration},
-    context::loader::{ASTNode, ContextLoader},
+    ast::{Expression, Mutability, VariableDeclaration},
+    context::{
+        browser::{Assignments, BinaryChecks, ContextBrowser},
+        loader::{ASTNode, ContextLoader},
+    },
     detect::detector::{Detector, IssueSeverity},
-    visitor::ast_visitor::{ASTConstVisitor, Node},
 };
 use eyre::Result;
-
-// TODO, this is actually a crazy compilcated detector for a fairly simple issue.
-// During the first context load of the contracts, the context should enable easy
-// retrieval of certain types inside of another type. For example, get all the Assignments
-// inside of a FunctionDefinition. This would make this detector much simpler.
 
 #[derive(Default)]
 pub struct ZeroAddressCheckDetector {
     // All the state variables, set at the beginning of the detect function
     mutable_address_state_variables: HashMap<i64, VariableDeclaration>,
 
-    // TRANSIENT VARIABLES
-    // HashMap where the key is the referenced_declaration in a binary operation that
-    // is checked against a zero address. The key will be a VariableDeclaration key
-    binary_checks_against_zero_address: HashMap<i64, bool>,
-    // HashMap where the key is the referenced_declaration of the right hand side of an assignment
-    // where the left hand side is a mutable address state variable
-    assignments_to_mutable_address_state_variables: HashMap<i64, Assignment>,
-
     // Keys are source file name and line number
     found_instances: BTreeMap<(String, usize), String>,
 }
 
-impl ZeroAddressCheckDetector {
-    fn reset_transient_variables(&mut self) {
-        self.binary_checks_against_zero_address = HashMap::new();
-        self.assignments_to_mutable_address_state_variables = HashMap::new();
-    }
-}
-
-impl ASTConstVisitor for ZeroAddressCheckDetector {
-    // if the left hand side referenced_declaration is in the mutable_address_state_variables return true
-    fn visit_assignment(&mut self, node: &Assignment) -> Result<bool> {
-        let left_hand_side = node.left_hand_side.as_ref();
-        if let Expression::Identifier(left_identifier) = left_hand_side {
-            if self
-                .mutable_address_state_variables
-                .contains_key(&left_identifier.referenced_declaration)
-            {
-                // add the right hand side referenced_declaration to the assignments_to_mutable_address_state_variables
-                let right_hand_side = node.right_hand_side.as_ref();
-                if let Expression::Identifier(right_identifier) = right_hand_side {
-                    self.assignments_to_mutable_address_state_variables
-                        .insert(right_identifier.referenced_declaration, node.clone());
-                }
-            }
-        };
-        Ok(true)
-    }
-
-    // If the binary
-    fn visit_binary_operation(&mut self, node: &BinaryOperation) -> Result<bool> {
-        // if the binaryoperation operator is "==" or "!="
-        if node.operator == "==" || node.operator == "!=" {
-            // if the left hand side is an identifier add its referenced_declaration to the binary_checks_against_zero_address
-            // OR
-            // if the right hand side is an identifier add its referenced_declaration to the binary_checks_against_zero_address
-            let left_expression = node.left_expression.as_ref();
-            if let Expression::Identifier(left_identifier) = left_expression {
-                self.binary_checks_against_zero_address
-                    .insert(left_identifier.referenced_declaration, true);
-            };
-
-            let right_expression = node.right_expression.as_ref();
-            if let Expression::Identifier(right_identifier) = right_expression {
-                self.binary_checks_against_zero_address
-                    .insert(right_identifier.referenced_declaration, true);
-            }
-        }
-        Ok(true)
-    }
-}
-
 impl Detector for ZeroAddressCheckDetector {
-    fn detect(&mut self, loader: &ContextLoader) -> Result<bool, Box<dyn Error>> {
+    fn detect(
+        &mut self,
+        loader: &ContextLoader,
+        browser: &mut ContextBrowser,
+    ) -> Result<bool, Box<dyn Error>> {
         // Get all address state variables
         self.mutable_address_state_variables = loader
             .variable_declarations
@@ -115,16 +58,72 @@ impl Detector for ZeroAddressCheckDetector {
 
         // Get all function definitions
         for function_definition in loader.function_definitions.keys() {
-            // Reset transient variables
-            self.reset_transient_variables();
-            // Visit the function definition using the BinaryOperator and Assignment visitors
-            function_definition.accept(self)?;
+            // Get all the binary checks inside the function
+            let binary_checks: BinaryChecks = function_definition.into();
+
+            // Filter the binary checks and extract all node ids into a vector
+            let mut binary_checks_against_zero_address = HashSet::new();
+
+            // HashSet where the key is the referenced_declaration in a binary operation that
+            // is checked against a zero address
+
+            let binary_checks = binary_checks
+                .checks
+                .iter()
+                .filter(|x| x.operator == "==" || x.operator == "!=");
+
+            for x in binary_checks {
+                if let Some(l_node_id) = x.l_node_id {
+                    binary_checks_against_zero_address.insert(l_node_id);
+                }
+                if let Some(r_node_ids) = x.r_node_id {
+                    binary_checks_against_zero_address.insert(r_node_ids);
+                }
+            }
+
+            // Get all the assignments in the function
+            let assigments: Assignments = function_definition.into();
+
+            // Filter out the ones of interest
+            let assignments = assigments
+                .assignments
+                .iter()
+                .filter_map(|x| {
+                    let left_hand_side = x.left_hand_side.as_ref();
+                    if let Expression::Identifier(left_identifier) = left_hand_side {
+                        if self
+                            .mutable_address_state_variables
+                            .contains_key(&left_identifier.referenced_declaration)
+                        {
+                            return Some(x);
+                        }
+                    }
+                    None
+                })
+                .filter_map(|x| {
+                    let right_hand_side = x.right_hand_side.as_ref();
+                    if let Expression::Identifier(right_identifier) = right_hand_side {
+                        return Some((right_identifier.referenced_declaration, x.clone()));
+                    }
+                    None
+                })
+                .collect::<Vec<_>>();
+
+            // HashMap where the key is the referenced_declaration of the right hand side of an assignment
+            // where the left hand side is a mutable address state variable
+
+            let mut assignments_to_mutable_address_state_variables = HashMap::new();
+
+            for tuple in &assignments {
+                assignments_to_mutable_address_state_variables.insert(tuple.0, tuple.1.clone());
+            }
+
             // if there are assignments to mutable address state variables that are not present
             // in the binary_checks_against_zero_address, add the assignment to the found_no_zero_address_check
-            for (key, value) in &self.assignments_to_mutable_address_state_variables {
-                if !self.binary_checks_against_zero_address.contains_key(key) {
+            for (key, value) in &assignments_to_mutable_address_state_variables {
+                if !binary_checks_against_zero_address.contains(&key) {
                     self.found_instances.insert(
-                        loader.get_node_sort_key(&ASTNode::Assignment(value.clone())),
+                        browser.get_node_sort_key(&ASTNode::Assignment(value.clone())),
                         value.src.clone(),
                     );
                 }
@@ -157,9 +156,12 @@ impl Detector for ZeroAddressCheckDetector {
 
 #[cfg(test)]
 mod zero_address_check_tests {
-    use crate::detect::{
-        detector::{detector_test_helpers::load_contract, Detector},
-        nc::zero_address_check::ZeroAddressCheckDetector,
+    use crate::{
+        context::browser::ContextBrowser,
+        detect::{
+            detector::{detector_test_helpers::load_contract, Detector},
+            nc::zero_address_check::ZeroAddressCheckDetector,
+        },
     };
 
     #[test]
@@ -167,8 +169,12 @@ mod zero_address_check_tests {
         let context_loader = load_contract(
             "../tests/contract-playground/out/StateVariables.sol/StateVariables.json",
         );
+        let mut context_browser = ContextBrowser::default_from(&context_loader);
+        context_browser.build_parallel();
         let mut detector = ZeroAddressCheckDetector::default();
-        let found = detector.detect(&context_loader).unwrap();
+        let found = detector
+            .detect(&context_loader, &mut context_browser)
+            .unwrap();
         // assert that the detector found the issue
         assert!(found);
         // assert that the detector found the correct number of issues

--- a/aderyn_core/src/lib.rs
+++ b/aderyn_core/src/lib.rs
@@ -37,7 +37,7 @@ where
 
     let mut report: Report = Report::default();
     for mut detector in detectors {
-        if let Ok(found) = detector.detect(&context_loader, &mut context_browser) {
+        if let Ok(found) = detector.detect(context_loader, &mut context_browser) {
             if found {
                 let issue: Issue = Issue {
                     title: detector.title(),
@@ -71,7 +71,7 @@ where
     reporter.print_report(
         get_markdown_writer(&output_file_path)?,
         &report,
-        &context_loader,
+        context_loader,
         root_rel_path,
         Some(output_file_path.clone()),
     )?;

--- a/aderyn_core/src/lib.rs
+++ b/aderyn_core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod fscloc;
 pub mod report;
 pub mod visitor;
 
+use context::browser::ContextBrowser;
 use eyre::Result;
 use std::error::Error;
 use std::fs::{remove_file, File};
@@ -19,10 +20,11 @@ use crate::report::reporter::Report;
 use crate::report::Issue;
 
 pub fn run_with_printer<T>(
-    context_loader: ContextLoader,
+    context_loader: &ContextLoader,
     output_file_path: String,
     reporter: T,
     root_rel_path: PathBuf,
+    mut context_browser: ContextBrowser,
 ) -> Result<(), Box<dyn Error>>
 where
     T: ReportPrinter<()>,
@@ -35,7 +37,7 @@ where
 
     let mut report: Report = Report::default();
     for mut detector in detectors {
-        if let Ok(found) = detector.detect(&context_loader) {
+        if let Ok(found) = detector.detect(&context_loader, &mut context_browser) {
             if found {
                 let issue: Issue = Issue {
                     title: detector.title(),

--- a/aderyn_driver/src/driver.rs
+++ b/aderyn_driver/src/driver.rs
@@ -1,5 +1,6 @@
 use crate::{process_foundry, process_hardhat, virtual_foundry};
 use aderyn_core::{
+    context::browser::ContextBrowser,
     fscloc,
     report::{json_printer::JsonPrinter, markdown_printer::MarkdownReportPrinter},
     run_with_printer,
@@ -52,23 +53,32 @@ pub fn drive(args: Args) {
     let stats = stats.lock().unwrap().to_owned();
     context_loader.set_sloc_stats(stats);
 
+    let mut context_browser = ContextBrowser::default_from(&context_loader);
+    context_browser.build_parallel();
+
     if args.output.ends_with(".json") {
         // Load the context loader into the run function, which runs the detectors
-        run_with_printer(context_loader, args.output, JsonPrinter, root_rel_path).unwrap_or_else(
-            |err| {
-                // Exit with a non-zero exit code
-                eprintln!("Error running aderyn");
-                eprintln!("{:?}", err);
-                std::process::exit(1);
-            },
-        );
+        run_with_printer(
+            &context_loader,
+            args.output,
+            JsonPrinter,
+            root_rel_path,
+            context_browser,
+        )
+        .unwrap_or_else(|err| {
+            // Exit with a non-zero exit code
+            eprintln!("Error running aderyn");
+            eprintln!("{:?}", err);
+            std::process::exit(1);
+        });
     } else {
         // Load the context loader into the run function, which runs the detectors
         run_with_printer(
-            context_loader,
+            &context_loader,
             args.output,
             MarkdownReportPrinter,
             root_rel_path,
+            context_browser,
         )
         .unwrap_or_else(|err| {
             // Exit with a non-zero exit code


### PR DESCRIPTION
```rust

         // Get all function definitions
        for function_definition in loader.function_definitions.keys() {
            // Get all the binary checks inside the function
            let binary_checks: BinaryChecks = function_definition.into();
            // {...}
            // Get all the assignments in the function
            let assigments: Assignments = function_definition.into();
            // {...}
        }

```

This PR will allow us to climb up this mountain
![image](https://github.com/Cyfrin/aderyn/assets/11134428/51a252e4-17ce-43ea-8788-83a7b014dbb0)

* ref: [https://craftinginterpreters.com/a-map-of-the-territory.html](https://craftinginterpreters.com/a-map-of-the-territory.html)

So far we were in step 5 which is the syntax tree (`ContextLoader`) - however for detectors to analyze the code comfortably we will need to take it up a notch to analysis (which is the peak) after which you go down again ...

That peak in the mountain is what I would like to  represent `ContextBrowser` with - it is passed along as a parameter to the `detect` function and it seeks to help make more friendly queries.

In this PR I have integrated that in the file `zero_address_check.rs` which was supposedly "Crazy Complex" Hopefully it is not that now !

If this works out, we can slowly start to integrate it for other detection modules : )


