### PR TITLE
Browser: GetParent - enable detectors to easily get a parent of a node

### DIFF
--- a/aderyn_core/src/context/browser/extractor.rs
+++ b/aderyn_core/src/context/browser/extractor.rs
@@ -11,7 +11,7 @@ pub struct ArrayTypeNameExtractor {
 }
 
 impl ArrayTypeNameExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut browser: ArrayTypeNameExtractor = Self::default();
         node.accept(&mut browser).unwrap_or_default();
         browser
@@ -32,7 +32,7 @@ pub struct AssignmentExtractor {
 }
 
 impl AssignmentExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut browser: AssignmentExtractor = Self::default();
         node.accept(&mut browser).unwrap_or_default();
         browser
@@ -53,7 +53,7 @@ pub struct BinaryOperationExtractor {
 }
 
 impl BinaryOperationExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut browser: BinaryOperationExtractor = Self::default();
         node.accept(&mut browser).unwrap_or_default();
         browser
@@ -74,7 +74,7 @@ pub struct BlockExtractor {
 }
 
 impl BlockExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -95,7 +95,7 @@ pub struct ConditionalExtractor {
 }
 
 impl ConditionalExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -116,7 +116,7 @@ pub struct ContractDefinitionExtractor {
 }
 
 impl ContractDefinitionExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -137,7 +137,7 @@ pub struct ElementaryTypeNameExtractor {
 }
 
 impl ElementaryTypeNameExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -158,7 +158,7 @@ pub struct ElementaryTypeNameExpressionExtractor {
 }
 
 impl ElementaryTypeNameExpressionExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -182,7 +182,7 @@ pub struct EmitStatementExtractor {
 }
 
 impl EmitStatementExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -203,7 +203,7 @@ pub struct EnumDefinitionExtractor {
 }
 
 impl EnumDefinitionExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -224,7 +224,7 @@ pub struct EnumValueExtractor {
 }
 
 impl EnumValueExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -245,7 +245,7 @@ pub struct EventDefinitionExtractor {
 }
 
 impl EventDefinitionExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -266,7 +266,7 @@ pub struct ErrorDefinitionExtractor {
 }
 
 impl ErrorDefinitionExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -287,7 +287,7 @@ pub struct ExpressionStatementExtractor {
 }
 
 impl ExpressionStatementExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -308,7 +308,7 @@ pub struct FunctionCallExtractor {
 }
 
 impl FunctionCallExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -330,7 +330,7 @@ pub struct FunctionDefinitionExtractor {
 }
 
 impl FunctionDefinitionExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -352,7 +352,7 @@ pub struct FunctionTypeNameExtractor {
 }
 
 impl FunctionTypeNameExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -374,7 +374,7 @@ pub struct ForStatementExtractor {
 }
 
 impl ForStatementExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -396,7 +396,7 @@ pub struct IdentifierExtractor {
 }
 
 impl IdentifierExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -418,7 +418,7 @@ pub struct IdentifierPathExtractor {
 }
 
 impl IdentifierPathExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -439,7 +439,7 @@ pub struct IfStatementExtractor {
 }
 
 impl IfStatementExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor: IfStatementExtractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -460,7 +460,7 @@ pub struct ImportDirectiveExtractor {
 }
 
 impl ImportDirectiveExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor: ImportDirectiveExtractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -481,7 +481,7 @@ pub struct IndexAccessExtractor {
 }
 
 impl IndexAccessExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor: IndexAccessExtractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -502,7 +502,7 @@ pub struct IndexRangeAccessExtractor {
 }
 
 impl IndexRangeAccessExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor: IndexRangeAccessExtractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -523,7 +523,7 @@ pub struct InheritanceSpecifierExtractor {
 }
 
 impl InheritanceSpecifierExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor: InheritanceSpecifierExtractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -544,7 +544,7 @@ pub struct InlineAssemblyExtractor {
 }
 
 impl InlineAssemblyExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor: InlineAssemblyExtractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -565,7 +565,7 @@ pub struct LiteralExtractor {
 }
 
 impl LiteralExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor: LiteralExtractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -586,7 +586,7 @@ pub struct MemberAccessExtractor {
 }
 
 impl MemberAccessExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut browser: MemberAccessExtractor = Self::default();
         node.accept(&mut browser).unwrap_or_default();
         browser
@@ -607,7 +607,7 @@ pub struct NewExpressionExtractor {
 }
 
 impl NewExpressionExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor: NewExpressionExtractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -628,7 +628,7 @@ pub struct MappingExtractor {
 }
 
 impl MappingExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor: MappingExtractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -649,7 +649,7 @@ pub struct ModifierDefinitionExtractor {
 }
 
 impl ModifierDefinitionExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor: ModifierDefinitionExtractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -670,7 +670,7 @@ pub struct ModifierInvocationExtractor {
 }
 
 impl ModifierInvocationExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor: ModifierInvocationExtractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -691,7 +691,7 @@ pub struct OverrideSpecifierExtractor {
 }
 
 impl OverrideSpecifierExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor: OverrideSpecifierExtractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -712,7 +712,7 @@ pub struct ParameterListExtractor {
 }
 
 impl ParameterListExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor: ParameterListExtractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -733,7 +733,7 @@ pub struct PragmaDirectiveExtractor {
 }
 
 impl PragmaDirectiveExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor: PragmaDirectiveExtractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -754,7 +754,7 @@ pub struct ReturnExtractor {
 }
 
 impl ReturnExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor: ReturnExtractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -775,7 +775,7 @@ pub struct RevertStatementExtractor {
 }
 
 impl RevertStatementExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor: RevertStatementExtractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -798,7 +798,7 @@ pub struct StructDefinitionExtractor {
 }
 
 impl StructDefinitionExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor: StructDefinitionExtractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -819,7 +819,7 @@ pub struct StructuredDocumentationExtractor {
 }
 
 impl StructuredDocumentationExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor: StructuredDocumentationExtractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -840,7 +840,7 @@ pub struct TryStatementExtractor {
 }
 
 impl TryStatementExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor: TryStatementExtractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -861,7 +861,7 @@ pub struct TryCatchClauseExtractor {
 }
 
 impl TryCatchClauseExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor: TryCatchClauseExtractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -882,7 +882,7 @@ pub struct TupleExpressionExtractor {
 }
 
 impl TupleExpressionExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor: TupleExpressionExtractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -903,7 +903,7 @@ pub struct UnaryOperationExtractor {
 }
 
 impl UnaryOperationExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor: UnaryOperationExtractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -924,7 +924,7 @@ pub struct UserDefinedTypeNameExtractor {
 }
 
 impl UserDefinedTypeNameExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor: UserDefinedTypeNameExtractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -945,7 +945,7 @@ pub struct UserDefinedValueTypeDefinitionExtractor {
 }
 
 impl UserDefinedValueTypeDefinitionExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor: UserDefinedValueTypeDefinitionExtractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -969,7 +969,7 @@ pub struct UsingForDirectiveExtractor {
 }
 
 impl UsingForDirectiveExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor: UsingForDirectiveExtractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -990,7 +990,7 @@ pub struct VariableDeclarationExtractor {
 }
 
 impl VariableDeclarationExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor: VariableDeclarationExtractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -1011,7 +1011,7 @@ pub struct VariableDeclarationStatementExtractor {
 }
 
 impl VariableDeclarationStatementExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor: VariableDeclarationStatementExtractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
@@ -1035,7 +1035,7 @@ pub struct WhileStatementExtractor {
 }
 
 impl WhileStatementExtractor {
-    pub fn from_node<T: Node + ?Sized>(node: &T) -> Self {
+    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor: WhileStatementExtractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor

--- a/aderyn_core/src/context/browser/extractor.rs
+++ b/aderyn_core/src/context/browser/extractor.rs
@@ -474,42 +474,42 @@ impl ASTConstVisitor for ExtractImportDirectives {
     }
 }
 
-// ExtractIndexAccesss extracts all IndexAccess nodes from a given node.
+// ExtractIndexAccesses extracts all IndexAccess nodes from a given node.
 #[derive(Default)]
-pub struct ExtractIndexAccesss {
+pub struct ExtractIndexAccesses {
     pub extracted: Vec<IndexAccess>,
 }
 
-impl ExtractIndexAccesss {
+impl ExtractIndexAccesses {
     pub fn from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut extractor: ExtractIndexAccesss = Self::default();
+        let mut extractor: ExtractIndexAccesses = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for ExtractIndexAccesss {
+impl ASTConstVisitor for ExtractIndexAccesses {
     fn visit_index_access(&mut self, node: &IndexAccess) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// ExtractIndexRangeAccesss extracts all IndexRangeAccess nodes from a given node.
+// ExtractIndexRangeAccesses extracts all IndexRangeAccess nodes from a given node.
 #[derive(Default)]
-pub struct ExtractIndexRangeAccesss {
+pub struct ExtractIndexRangeAccesses {
     pub extracted: Vec<IndexRangeAccess>,
 }
 
-impl ExtractIndexRangeAccesss {
+impl ExtractIndexRangeAccesses {
     pub fn from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut extractor: ExtractIndexRangeAccesss = Self::default();
+        let mut extractor: ExtractIndexRangeAccesses = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for ExtractIndexRangeAccesss {
+impl ASTConstVisitor for ExtractIndexRangeAccesses {
     fn visit_index_range_access(&mut self, node: &IndexRangeAccess) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
@@ -579,21 +579,21 @@ impl ASTConstVisitor for ExtractLiterals {
     }
 }
 
-// ExtractMemberAccesss is an extractor that extracts all MemberAccess nodes from a node.
+// ExtractMemberAccesses is an extractor that extracts all MemberAccess nodes from a node.
 #[derive(Default)]
-pub struct ExtractMemberAccesss {
+pub struct ExtractMemberAccesses {
     pub extracted: Vec<MemberAccess>,
 }
 
-impl ExtractMemberAccesss {
+impl ExtractMemberAccesses {
     pub fn from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut extractor: ExtractMemberAccesss = Self::default();
+        let mut extractor: ExtractMemberAccesses = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for ExtractMemberAccesss {
+impl ASTConstVisitor for ExtractMemberAccesses {
     fn visit_member_access(&mut self, node: &MemberAccess) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)

--- a/aderyn_core/src/context/browser/extractor.rs
+++ b/aderyn_core/src/context/browser/extractor.rs
@@ -4,168 +4,168 @@ use crate::{
 };
 use eyre::Result;
 
-// ArrayTypeNameExtractor is a browser that extracts all ArrayTypeName nodes from a node.
+// ExtractArrayTypeNames is an extractor that extracts all ArrayTypeName nodes from a node.
 #[derive(Default)]
-pub struct ArrayTypeNameExtractor {
+pub struct ExtractArrayTypeNames {
     pub extracted: Vec<ArrayTypeName>,
 }
 
-impl ArrayTypeNameExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut browser: ArrayTypeNameExtractor = Self::default();
-        node.accept(&mut browser).unwrap_or_default();
-        browser
+impl ExtractArrayTypeNames {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
+        let mut extractor: ExtractArrayTypeNames = Self::default();
+        node.accept(&mut extractor).unwrap_or_default();
+        extractor
     }
 }
 
-impl ASTConstVisitor for ArrayTypeNameExtractor {
+impl ASTConstVisitor for ExtractArrayTypeNames {
     fn visit_array_type_name(&mut self, node: &ArrayTypeName) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// AssignmentExtractor is a browser that extracts all Assignments nodes from a node.
+// ExtractAssignments is an extractor that extracts all Assignments nodes from a node.
 #[derive(Default)]
-pub struct AssignmentExtractor {
+pub struct ExtractAssignments {
     pub extracted: Vec<Assignment>,
 }
 
-impl AssignmentExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut browser: AssignmentExtractor = Self::default();
-        node.accept(&mut browser).unwrap_or_default();
-        browser
+impl ExtractAssignments {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
+        let mut extractor: ExtractAssignments = Self::default();
+        node.accept(&mut extractor).unwrap_or_default();
+        extractor
     }
 }
 
-impl ASTConstVisitor for AssignmentExtractor {
+impl ASTConstVisitor for ExtractAssignments {
     fn visit_assignment(&mut self, node: &Assignment) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// BinaryOperationExtractor is a browser that extracts all BinaryOperations nodes from a node.
+// ExtractBinaryOperations is an extractor that extracts all BinaryOperations nodes from a node.
 #[derive(Default)]
-pub struct BinaryOperationExtractor {
+pub struct ExtractBinaryOperations {
     pub extracted: Vec<BinaryOperation>,
 }
 
-impl BinaryOperationExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut browser: BinaryOperationExtractor = Self::default();
-        node.accept(&mut browser).unwrap_or_default();
-        browser
+impl ExtractBinaryOperations {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
+        let mut extractor: ExtractBinaryOperations = Self::default();
+        node.accept(&mut extractor).unwrap_or_default();
+        extractor
     }
 }
 
-impl ASTConstVisitor for BinaryOperationExtractor {
+impl ASTConstVisitor for ExtractBinaryOperations {
     fn visit_binary_operation(&mut self, node: &BinaryOperation) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// BlockExtractor extracts all Block nodes from a given node.
+// ExtractBlocks extracts all Block nodes from a given node.
 #[derive(Default)]
-pub struct BlockExtractor {
+pub struct ExtractBlocks {
     pub extracted: Vec<Block>,
 }
 
-impl BlockExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
+impl ExtractBlocks {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for BlockExtractor {
+impl ASTConstVisitor for ExtractBlocks {
     fn visit_block(&mut self, node: &Block) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// ConditionalExtractor extracts all Conditional nodes from a given node.
+// ExtractConditionals extracts all Conditional nodes from a given node.
 #[derive(Default)]
-pub struct ConditionalExtractor {
+pub struct ExtractConditionals {
     pub extracted: Vec<Conditional>,
 }
 
-impl ConditionalExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
+impl ExtractConditionals {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for ConditionalExtractor {
+impl ASTConstVisitor for ExtractConditionals {
     fn visit_conditional(&mut self, node: &Conditional) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// ContractDefinitionExtractor extracts all ContractDefinition nodes from a given node.
+// ExtractContractDefinitions extracts all ContractDefinition nodes from a given node.
 #[derive(Default)]
-pub struct ContractDefinitionExtractor {
+pub struct ExtractContractDefinitions {
     pub extracted: Vec<ContractDefinition>,
 }
 
-impl ContractDefinitionExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
+impl ExtractContractDefinitions {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for ContractDefinitionExtractor {
+impl ASTConstVisitor for ExtractContractDefinitions {
     fn visit_contract_definition(&mut self, node: &ContractDefinition) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// ElementaryTypeNameExtractor extracts all ElementaryTypeName nodes from a given node.
+// ExtractElementaryTypeNames extracts all ElementaryTypeName nodes from a given node.
 #[derive(Default)]
-pub struct ElementaryTypeNameExtractor {
+pub struct ExtractElementaryTypeNames {
     pub extracted: Vec<ElementaryTypeName>,
 }
 
-impl ElementaryTypeNameExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
+impl ExtractElementaryTypeNames {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for ElementaryTypeNameExtractor {
+impl ASTConstVisitor for ExtractElementaryTypeNames {
     fn visit_elementary_type_name(&mut self, node: &ElementaryTypeName) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// ElementaryTypeNameExpressionExtractor extracts all ElementaryTypeNameExpression nodes from a given node.
+// ExtractElementaryTypeNameExpressions extracts all ElementaryTypeNameExpression nodes from a given node.
 #[derive(Default)]
-pub struct ElementaryTypeNameExpressionExtractor {
+pub struct ExtractElementaryTypeNameExpressions {
     pub extracted: Vec<ElementaryTypeNameExpression>,
 }
 
-impl ElementaryTypeNameExpressionExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
+impl ExtractElementaryTypeNameExpressions {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for ElementaryTypeNameExpressionExtractor {
+impl ASTConstVisitor for ExtractElementaryTypeNameExpressions {
     fn visit_elementary_type_name_expression(
         &mut self,
         node: &ElementaryTypeNameExpression,
@@ -175,784 +175,784 @@ impl ASTConstVisitor for ElementaryTypeNameExpressionExtractor {
     }
 }
 
-// EmitStatementExtractor extracts all EmitStatement nodes from a given node.
+// ExtractEmitStatements extracts all EmitStatement nodes from a given node.
 #[derive(Default)]
-pub struct EmitStatementExtractor {
+pub struct ExtractEmitStatements {
     pub extracted: Vec<EmitStatement>,
 }
 
-impl EmitStatementExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
+impl ExtractEmitStatements {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for EmitStatementExtractor {
+impl ASTConstVisitor for ExtractEmitStatements {
     fn visit_emit_statement(&mut self, node: &EmitStatement) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// EnumDefinitionExtractor extracts all EnumDefinition nodes from a given node.
+// ExtractEnumDefinitions extracts all EnumDefinition nodes from a given node.
 #[derive(Default)]
-pub struct EnumDefinitionExtractor {
+pub struct ExtractEnumDefinitions {
     pub extracted: Vec<EnumDefinition>,
 }
 
-impl EnumDefinitionExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
+impl ExtractEnumDefinitions {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for EnumDefinitionExtractor {
+impl ASTConstVisitor for ExtractEnumDefinitions {
     fn visit_enum_definition(&mut self, node: &EnumDefinition) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// EnumValueExtractor extracts all EnumValue nodes from a given node.
+// ExtractEnumValues extracts all EnumValue nodes from a given node.
 #[derive(Default)]
-pub struct EnumValueExtractor {
+pub struct ExtractEnumValues {
     pub extracted: Vec<EnumValue>,
 }
 
-impl EnumValueExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
+impl ExtractEnumValues {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for EnumValueExtractor {
+impl ASTConstVisitor for ExtractEnumValues {
     fn visit_enum_value(&mut self, node: &EnumValue) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// EventDefinitionExtractor extracts all EventDefinition nodes from a given node.
+// ExtractEventDefinitions extracts all EventDefinition nodes from a given node.
 #[derive(Default)]
-pub struct EventDefinitionExtractor {
+pub struct ExtractEventDefinitions {
     pub extracted: Vec<EventDefinition>,
 }
 
-impl EventDefinitionExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
+impl ExtractEventDefinitions {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for EventDefinitionExtractor {
+impl ASTConstVisitor for ExtractEventDefinitions {
     fn visit_event_definition(&mut self, node: &EventDefinition) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// ErrorDefinitionExtractor extracts all ErrorDefinition nodes from a given node.
+// ExtractErrorDefinitions extracts all ErrorDefinition nodes from a given node.
 #[derive(Default)]
-pub struct ErrorDefinitionExtractor {
+pub struct ExtractErrorDefinitions {
     pub extracted: Vec<ErrorDefinition>,
 }
 
-impl ErrorDefinitionExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
+impl ExtractErrorDefinitions {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for ErrorDefinitionExtractor {
+impl ASTConstVisitor for ExtractErrorDefinitions {
     fn visit_error_definition(&mut self, node: &ErrorDefinition) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// ExpressionStatementExtractor extracts all ExpressionStatement nodes from a given node.
+// ExtractExpressionStatements extracts all ExpressionStatement nodes from a given node.
 #[derive(Default)]
-pub struct ExpressionStatementExtractor {
+pub struct ExtractExpressionStatements {
     pub extracted: Vec<ExpressionStatement>,
 }
 
-impl ExpressionStatementExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
+impl ExtractExpressionStatements {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for ExpressionStatementExtractor {
+impl ASTConstVisitor for ExtractExpressionStatements {
     fn visit_expression_statement(&mut self, node: &ExpressionStatement) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// FunctionCallExtractor extracts all FunctionCall nodes from a given node.
+// ExtractFunctionCalls extracts all FunctionCall nodes from a given node.
 #[derive(Default)]
-pub struct FunctionCallExtractor {
+pub struct ExtractFunctionCalls {
     pub extracted: Vec<FunctionCall>,
 }
 
-impl FunctionCallExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
+impl ExtractFunctionCalls {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for FunctionCallExtractor {
+impl ASTConstVisitor for ExtractFunctionCalls {
     fn visit_function_call(&mut self, node: &FunctionCall) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// FunctionDefinitionExtractor extracts all FunctionDefinition nodes from a given node.
+// ExtractFunctionDefinitions extracts all FunctionDefinition nodes from a given node.
 #[derive(Default)]
 
-pub struct FunctionDefinitionExtractor {
+pub struct ExtractFunctionDefinitions {
     pub extracted: Vec<FunctionDefinition>,
 }
 
-impl FunctionDefinitionExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
+impl ExtractFunctionDefinitions {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for FunctionDefinitionExtractor {
+impl ASTConstVisitor for ExtractFunctionDefinitions {
     fn visit_function_definition(&mut self, node: &FunctionDefinition) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// FunctionTypeNameExtractor extracts all FunctionTypeName nodes from a given node.
+// ExtractFunctionTypeNames extracts all FunctionTypeName nodes from a given node.
 #[derive(Default)]
 
-pub struct FunctionTypeNameExtractor {
+pub struct ExtractFunctionTypeNames {
     pub extracted: Vec<FunctionTypeName>,
 }
 
-impl FunctionTypeNameExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
+impl ExtractFunctionTypeNames {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for FunctionTypeNameExtractor {
+impl ASTConstVisitor for ExtractFunctionTypeNames {
     fn visit_function_type_name(&mut self, node: &FunctionTypeName) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// ForStatementExtractor extracts all ForStatement nodes from a given node.
+// ExtractForStatements extracts all ForStatement nodes from a given node.
 #[derive(Default)]
 
-pub struct ForStatementExtractor {
+pub struct ExtractForStatements {
     pub extracted: Vec<ForStatement>,
 }
 
-impl ForStatementExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
+impl ExtractForStatements {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for ForStatementExtractor {
+impl ASTConstVisitor for ExtractForStatements {
     fn visit_for_statement(&mut self, node: &ForStatement) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// IdentifierExtractor extracts all Identifier nodes from a given node.
+// ExtractIdentifiers extracts all Identifier nodes from a given node.
 #[derive(Default)]
 
-pub struct IdentifierExtractor {
+pub struct ExtractIdentifiers {
     pub extracted: Vec<Identifier>,
 }
 
-impl IdentifierExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
+impl ExtractIdentifiers {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for IdentifierExtractor {
+impl ASTConstVisitor for ExtractIdentifiers {
     fn visit_identifier(&mut self, node: &Identifier) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// IdentifierPathExtractor extracts all IdentifierPath nodes from a given node.
+// ExtractIdentifierPaths extracts all IdentifierPath nodes from a given node.
 #[derive(Default)]
 
-pub struct IdentifierPathExtractor {
+pub struct ExtractIdentifierPaths {
     pub extracted: Vec<IdentifierPath>,
 }
 
-impl IdentifierPathExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
+impl ExtractIdentifierPaths {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
         let mut extractor = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for IdentifierPathExtractor {
+impl ASTConstVisitor for ExtractIdentifierPaths {
     fn visit_identifier_path(&mut self, node: &IdentifierPath) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// IfStatementExtractor extracts all IfStatement nodes from a given node.
+// ExtractIfStatements extracts all IfStatement nodes from a given node.
 #[derive(Default)]
-pub struct IfStatementExtractor {
+pub struct ExtractIfStatements {
     pub extracted: Vec<IfStatement>,
 }
 
-impl IfStatementExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut extractor: IfStatementExtractor = Self::default();
+impl ExtractIfStatements {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
+        let mut extractor: ExtractIfStatements = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for IfStatementExtractor {
+impl ASTConstVisitor for ExtractIfStatements {
     fn visit_if_statement(&mut self, node: &IfStatement) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// ImportDirectiveExtractor extracts all ImportDirective nodes from a given node.
+// ExtractImportDirectives extracts all ImportDirective nodes from a given node.
 #[derive(Default)]
-pub struct ImportDirectiveExtractor {
+pub struct ExtractImportDirectives {
     pub extracted: Vec<ImportDirective>,
 }
 
-impl ImportDirectiveExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut extractor: ImportDirectiveExtractor = Self::default();
+impl ExtractImportDirectives {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
+        let mut extractor: ExtractImportDirectives = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for ImportDirectiveExtractor {
+impl ASTConstVisitor for ExtractImportDirectives {
     fn visit_import_directive(&mut self, node: &ImportDirective) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// IndexAccessExtractor extracts all IndexAccess nodes from a given node.
+// ExtractIndexAccesss extracts all IndexAccess nodes from a given node.
 #[derive(Default)]
-pub struct IndexAccessExtractor {
+pub struct ExtractIndexAccesss {
     pub extracted: Vec<IndexAccess>,
 }
 
-impl IndexAccessExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut extractor: IndexAccessExtractor = Self::default();
+impl ExtractIndexAccesss {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
+        let mut extractor: ExtractIndexAccesss = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for IndexAccessExtractor {
+impl ASTConstVisitor for ExtractIndexAccesss {
     fn visit_index_access(&mut self, node: &IndexAccess) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// IndexRangeAccessExtractor extracts all IndexRangeAccess nodes from a given node.
+// ExtractIndexRangeAccesss extracts all IndexRangeAccess nodes from a given node.
 #[derive(Default)]
-pub struct IndexRangeAccessExtractor {
+pub struct ExtractIndexRangeAccesss {
     pub extracted: Vec<IndexRangeAccess>,
 }
 
-impl IndexRangeAccessExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut extractor: IndexRangeAccessExtractor = Self::default();
+impl ExtractIndexRangeAccesss {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
+        let mut extractor: ExtractIndexRangeAccesss = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for IndexRangeAccessExtractor {
+impl ASTConstVisitor for ExtractIndexRangeAccesss {
     fn visit_index_range_access(&mut self, node: &IndexRangeAccess) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// InheritanceSpecifierExtractor extracts all InheritanceSpecifier nodes from a given node.
+// ExtractInheritanceSpecifiers extracts all InheritanceSpecifier nodes from a given node.
 #[derive(Default)]
-pub struct InheritanceSpecifierExtractor {
+pub struct ExtractInheritanceSpecifiers {
     pub extracted: Vec<InheritanceSpecifier>,
 }
 
-impl InheritanceSpecifierExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut extractor: InheritanceSpecifierExtractor = Self::default();
+impl ExtractInheritanceSpecifiers {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
+        let mut extractor: ExtractInheritanceSpecifiers = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for InheritanceSpecifierExtractor {
+impl ASTConstVisitor for ExtractInheritanceSpecifiers {
     fn visit_inheritance_specifier(&mut self, node: &InheritanceSpecifier) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// InlineAssemblyExtractor extracts all InlineAssembly nodes from a given node.
+// ExtractInlineAssemblys extracts all InlineAssembly nodes from a given node.
 #[derive(Default)]
-pub struct InlineAssemblyExtractor {
+pub struct ExtractInlineAssemblys {
     pub extracted: Vec<InlineAssembly>,
 }
 
-impl InlineAssemblyExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut extractor: InlineAssemblyExtractor = Self::default();
+impl ExtractInlineAssemblys {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
+        let mut extractor: ExtractInlineAssemblys = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for InlineAssemblyExtractor {
+impl ASTConstVisitor for ExtractInlineAssemblys {
     fn visit_inline_assembly(&mut self, node: &InlineAssembly) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// LiteralExtractor extracts all Literal nodes from a given node.
+// ExtractLiterals extracts all Literal nodes from a given node.
 #[derive(Default)]
-pub struct LiteralExtractor {
+pub struct ExtractLiterals {
     pub extracted: Vec<Literal>,
 }
 
-impl LiteralExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut extractor: LiteralExtractor = Self::default();
+impl ExtractLiterals {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
+        let mut extractor: ExtractLiterals = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for LiteralExtractor {
+impl ASTConstVisitor for ExtractLiterals {
     fn visit_literal(&mut self, node: &Literal) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// MemberAccessExtractor is a browser that extracts all MemberAccess nodes from a node.
+// ExtractMemberAccesss is an extractor that extracts all MemberAccess nodes from a node.
 #[derive(Default)]
-pub struct MemberAccessExtractor {
+pub struct ExtractMemberAccesss {
     pub extracted: Vec<MemberAccess>,
 }
 
-impl MemberAccessExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut browser: MemberAccessExtractor = Self::default();
-        node.accept(&mut browser).unwrap_or_default();
-        browser
+impl ExtractMemberAccesss {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
+        let mut extractor: ExtractMemberAccesss = Self::default();
+        node.accept(&mut extractor).unwrap_or_default();
+        extractor
     }
 }
 
-impl ASTConstVisitor for MemberAccessExtractor {
+impl ASTConstVisitor for ExtractMemberAccesss {
     fn visit_member_access(&mut self, node: &MemberAccess) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// NewExpressionExtractor extracts all NewExpression nodes from a given node.
+// ExtractNewExpressions extracts all NewExpression nodes from a given node.
 #[derive(Default)]
-pub struct NewExpressionExtractor {
+pub struct ExtractNewExpressions {
     pub extracted: Vec<NewExpression>,
 }
 
-impl NewExpressionExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut extractor: NewExpressionExtractor = Self::default();
+impl ExtractNewExpressions {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
+        let mut extractor: ExtractNewExpressions = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for NewExpressionExtractor {
+impl ASTConstVisitor for ExtractNewExpressions {
     fn visit_new_expression(&mut self, node: &NewExpression) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// MappingExtractor extracts all Mapping nodes from a given node.
+// ExtractMappings extracts all Mapping nodes from a given node.
 #[derive(Default)]
-pub struct MappingExtractor {
+pub struct ExtractMappings {
     pub extracted: Vec<Mapping>,
 }
 
-impl MappingExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut extractor: MappingExtractor = Self::default();
+impl ExtractMappings {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
+        let mut extractor: ExtractMappings = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for MappingExtractor {
+impl ASTConstVisitor for ExtractMappings {
     fn visit_mapping(&mut self, node: &Mapping) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// ModifierDefinitionExtractor extracts all ModifierDefinition nodes from a given node.
+// ExtractModifierDefinitions extracts all ModifierDefinition nodes from a given node.
 #[derive(Default)]
-pub struct ModifierDefinitionExtractor {
+pub struct ExtractModifierDefinitions {
     pub extracted: Vec<ModifierDefinition>,
 }
 
-impl ModifierDefinitionExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut extractor: ModifierDefinitionExtractor = Self::default();
+impl ExtractModifierDefinitions {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
+        let mut extractor: ExtractModifierDefinitions = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for ModifierDefinitionExtractor {
+impl ASTConstVisitor for ExtractModifierDefinitions {
     fn visit_modifier_definition(&mut self, node: &ModifierDefinition) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// ModifierInvocationExtractor extracts all ModifierInvocation nodes from a given node.
+// ExtractModifierInvocations extracts all ModifierInvocation nodes from a given node.
 #[derive(Default)]
-pub struct ModifierInvocationExtractor {
+pub struct ExtractModifierInvocations {
     pub extracted: Vec<ModifierInvocation>,
 }
 
-impl ModifierInvocationExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut extractor: ModifierInvocationExtractor = Self::default();
+impl ExtractModifierInvocations {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
+        let mut extractor: ExtractModifierInvocations = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for ModifierInvocationExtractor {
+impl ASTConstVisitor for ExtractModifierInvocations {
     fn visit_modifier_invocation(&mut self, node: &ModifierInvocation) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// OverrideSpecifierExtractor extracts all OverrideSpecifier nodes from a given node.
+// ExtractOverrideSpecifiers extracts all OverrideSpecifier nodes from a given node.
 #[derive(Default)]
-pub struct OverrideSpecifierExtractor {
+pub struct ExtractOverrideSpecifiers {
     pub extracted: Vec<OverrideSpecifier>,
 }
 
-impl OverrideSpecifierExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut extractor: OverrideSpecifierExtractor = Self::default();
+impl ExtractOverrideSpecifiers {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
+        let mut extractor: ExtractOverrideSpecifiers = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for OverrideSpecifierExtractor {
+impl ASTConstVisitor for ExtractOverrideSpecifiers {
     fn visit_override_specifier(&mut self, node: &OverrideSpecifier) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// ParameterListExtractor extracts all ParameterList nodes from a given node.
+// ExtractParameterLists extracts all ParameterList nodes from a given node.
 #[derive(Default)]
-pub struct ParameterListExtractor {
+pub struct ExtractParameterLists {
     pub extracted: Vec<ParameterList>,
 }
 
-impl ParameterListExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut extractor: ParameterListExtractor = Self::default();
+impl ExtractParameterLists {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
+        let mut extractor: ExtractParameterLists = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for ParameterListExtractor {
+impl ASTConstVisitor for ExtractParameterLists {
     fn visit_parameter_list(&mut self, node: &ParameterList) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// PragmaDirectiveExtractor extracts all PragmaDirective nodes from a given node.
+// ExtractPragmaDirectives extracts all PragmaDirective nodes from a given node.
 #[derive(Default)]
-pub struct PragmaDirectiveExtractor {
+pub struct ExtractPragmaDirectives {
     pub extracted: Vec<PragmaDirective>,
 }
 
-impl PragmaDirectiveExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut extractor: PragmaDirectiveExtractor = Self::default();
+impl ExtractPragmaDirectives {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
+        let mut extractor: ExtractPragmaDirectives = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for PragmaDirectiveExtractor {
+impl ASTConstVisitor for ExtractPragmaDirectives {
     fn visit_pragma_directive(&mut self, node: &PragmaDirective) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// ReturnExtractor extracts all Return nodes from a given node.
+// ExtractReturns extracts all Return nodes from a given node.
 #[derive(Default)]
-pub struct ReturnExtractor {
+pub struct ExtractReturns {
     pub extracted: Vec<Return>,
 }
 
-impl ReturnExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut extractor: ReturnExtractor = Self::default();
+impl ExtractReturns {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
+        let mut extractor: ExtractReturns = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for ReturnExtractor {
+impl ASTConstVisitor for ExtractReturns {
     fn visit_return(&mut self, node: &Return) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// RevertStatementExtractor extracts all RevertStatement nodes from a given node.
+// ExtractRevertStatements extracts all RevertStatement nodes from a given node.
 #[derive(Default)]
-pub struct RevertStatementExtractor {
+pub struct ExtractRevertStatements {
     pub extracted: Vec<RevertStatement>,
 }
 
-impl RevertStatementExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut extractor: RevertStatementExtractor = Self::default();
+impl ExtractRevertStatements {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
+        let mut extractor: ExtractRevertStatements = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for RevertStatementExtractor {
+impl ASTConstVisitor for ExtractRevertStatements {
     fn visit_revert_statement(&mut self, node: &RevertStatement) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// SourceUnitExtractor is not needed
+// ExtractSourceUnits is not needed
 
-// StructDefinitionExtractor extracts all StructDefinition nodes from a given node.
+// ExtractStructDefinitions extracts all StructDefinition nodes from a given node.
 #[derive(Default)]
-pub struct StructDefinitionExtractor {
+pub struct ExtractStructDefinitions {
     pub extracted: Vec<StructDefinition>,
 }
 
-impl StructDefinitionExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut extractor: StructDefinitionExtractor = Self::default();
+impl ExtractStructDefinitions {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
+        let mut extractor: ExtractStructDefinitions = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for StructDefinitionExtractor {
+impl ASTConstVisitor for ExtractStructDefinitions {
     fn visit_struct_definition(&mut self, node: &StructDefinition) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// StructuredDocumentationExtractor extracts all StructuredDocumentation nodes from a given node.
+// ExtractStructuredDocumentations extracts all StructuredDocumentation nodes from a given node.
 #[derive(Default)]
-pub struct StructuredDocumentationExtractor {
+pub struct ExtractStructuredDocumentations {
     pub extracted: Vec<StructuredDocumentation>,
 }
 
-impl StructuredDocumentationExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut extractor: StructuredDocumentationExtractor = Self::default();
+impl ExtractStructuredDocumentations {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
+        let mut extractor: ExtractStructuredDocumentations = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for StructuredDocumentationExtractor {
+impl ASTConstVisitor for ExtractStructuredDocumentations {
     fn visit_structured_documentation(&mut self, node: &StructuredDocumentation) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// TryStatementExtractor extracts all TryStatement nodes from a given node.
+// ExtractTryStatements extracts all TryStatement nodes from a given node.
 #[derive(Default)]
-pub struct TryStatementExtractor {
+pub struct ExtractTryStatements {
     pub extracted: Vec<TryStatement>,
 }
 
-impl TryStatementExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut extractor: TryStatementExtractor = Self::default();
+impl ExtractTryStatements {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
+        let mut extractor: ExtractTryStatements = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for TryStatementExtractor {
+impl ASTConstVisitor for ExtractTryStatements {
     fn visit_try_statement(&mut self, node: &TryStatement) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// TryCatchClauseExtractor extracts all TryCatchClause nodes from a given node.
+// ExtractTryCatchClauses extracts all TryCatchClause nodes from a given node.
 #[derive(Default)]
-pub struct TryCatchClauseExtractor {
+pub struct ExtractTryCatchClauses {
     pub extracted: Vec<TryCatchClause>,
 }
 
-impl TryCatchClauseExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut extractor: TryCatchClauseExtractor = Self::default();
+impl ExtractTryCatchClauses {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
+        let mut extractor: ExtractTryCatchClauses = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for TryCatchClauseExtractor {
+impl ASTConstVisitor for ExtractTryCatchClauses {
     fn visit_try_catch_clause(&mut self, node: &TryCatchClause) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// TupleExpressionExtractor extracts all TupleExpression nodes from a given node.
+// ExtractTupleExpressions extracts all TupleExpression nodes from a given node.
 #[derive(Default)]
-pub struct TupleExpressionExtractor {
+pub struct ExtractTupleExpressions {
     pub extracted: Vec<TupleExpression>,
 }
 
-impl TupleExpressionExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut extractor: TupleExpressionExtractor = Self::default();
+impl ExtractTupleExpressions {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
+        let mut extractor: ExtractTupleExpressions = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for TupleExpressionExtractor {
+impl ASTConstVisitor for ExtractTupleExpressions {
     fn visit_tuple_expression(&mut self, node: &TupleExpression) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// UnaryOperationExtractor extracts all UnaryOperations nodes from a given node.
+// ExtractUnaryOperations extracts all UnaryOperations nodes from a given node.
 #[derive(Default)]
-pub struct UnaryOperationExtractor {
+pub struct ExtractUnaryOperations {
     pub extracted: Vec<UnaryOperation>,
 }
 
-impl UnaryOperationExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut extractor: UnaryOperationExtractor = Self::default();
+impl ExtractUnaryOperations {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
+        let mut extractor: ExtractUnaryOperations = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for UnaryOperationExtractor {
+impl ASTConstVisitor for ExtractUnaryOperations {
     fn visit_unary_operation(&mut self, node: &UnaryOperation) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// UserDefinedTypeNameExtractor extracts all UserDefinedTypeName nodes from a given node.
+// ExtractUserDefinedTypeNames extracts all UserDefinedTypeName nodes from a given node.
 #[derive(Default)]
-pub struct UserDefinedTypeNameExtractor {
+pub struct ExtractUserDefinedTypeNames {
     pub extracted: Vec<UserDefinedTypeName>,
 }
 
-impl UserDefinedTypeNameExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut extractor: UserDefinedTypeNameExtractor = Self::default();
+impl ExtractUserDefinedTypeNames {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
+        let mut extractor: ExtractUserDefinedTypeNames = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for UserDefinedTypeNameExtractor {
+impl ASTConstVisitor for ExtractUserDefinedTypeNames {
     fn visit_user_defined_type_name(&mut self, node: &UserDefinedTypeName) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// UserDefinedValueTypeDefinitionExtractor extracts all UserDefinedValueTypes nodes from a given node.
+// ExtractUserDefinedValueTypeDefinitions extracts all UserDefinedValueTypes nodes from a given node.
 #[derive(Default)]
-pub struct UserDefinedValueTypeDefinitionExtractor {
+pub struct ExtractUserDefinedValueTypeDefinitions {
     pub extracted: Vec<UserDefinedValueTypeDefinition>,
 }
 
-impl UserDefinedValueTypeDefinitionExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut extractor: UserDefinedValueTypeDefinitionExtractor = Self::default();
+impl ExtractUserDefinedValueTypeDefinitions {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
+        let mut extractor: ExtractUserDefinedValueTypeDefinitions = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for UserDefinedValueTypeDefinitionExtractor {
+impl ASTConstVisitor for ExtractUserDefinedValueTypeDefinitions {
     fn visit_user_defined_value_type_definition(
         &mut self,
         node: &UserDefinedValueTypeDefinition,
@@ -962,63 +962,63 @@ impl ASTConstVisitor for UserDefinedValueTypeDefinitionExtractor {
     }
 }
 
-// UsingForDirectiveExtractor extracts all UsingForDirective nodes from a given node.
+// ExtractUsingForDirectives extracts all UsingForDirective nodes from a given node.
 #[derive(Default)]
-pub struct UsingForDirectiveExtractor {
+pub struct ExtractUsingForDirectives {
     pub extracted: Vec<UsingForDirective>,
 }
 
-impl UsingForDirectiveExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut extractor: UsingForDirectiveExtractor = Self::default();
+impl ExtractUsingForDirectives {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
+        let mut extractor: ExtractUsingForDirectives = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for UsingForDirectiveExtractor {
+impl ASTConstVisitor for ExtractUsingForDirectives {
     fn visit_using_for_directive(&mut self, node: &UsingForDirective) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// VariableDeclarationExtractor extracts all VariableDeclaration nodes from a given node.
+// ExtractVariableDeclarations extracts all VariableDeclaration nodes from a given node.
 #[derive(Default)]
-pub struct VariableDeclarationExtractor {
+pub struct ExtractVariableDeclarations {
     pub extracted: Vec<VariableDeclaration>,
 }
 
-impl VariableDeclarationExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut extractor: VariableDeclarationExtractor = Self::default();
+impl ExtractVariableDeclarations {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
+        let mut extractor: ExtractVariableDeclarations = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for VariableDeclarationExtractor {
+impl ASTConstVisitor for ExtractVariableDeclarations {
     fn visit_variable_declaration(&mut self, node: &VariableDeclaration) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)
     }
 }
 
-// VariableDeclarationStatementExtractor extracts all VariableDeclarationStatement nodes from a given node.
+// ExtractVariableDeclarationStatements extracts all VariableDeclarationStatement nodes from a given node.
 #[derive(Default)]
-pub struct VariableDeclarationStatementExtractor {
+pub struct ExtractVariableDeclarationStatements {
     pub extracted: Vec<VariableDeclarationStatement>,
 }
 
-impl VariableDeclarationStatementExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut extractor: VariableDeclarationStatementExtractor = Self::default();
+impl ExtractVariableDeclarationStatements {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
+        let mut extractor: ExtractVariableDeclarationStatements = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for VariableDeclarationStatementExtractor {
+impl ASTConstVisitor for ExtractVariableDeclarationStatements {
     fn visit_variable_declaration_statement(
         &mut self,
         node: &VariableDeclarationStatement,
@@ -1028,21 +1028,21 @@ impl ASTConstVisitor for VariableDeclarationStatementExtractor {
     }
 }
 
-// WhileStatementExtractor extracts all WhileStatement nodes from a given node.
+// ExtractWhileStatements extracts all WhileStatement nodes from a given node.
 #[derive(Default)]
-pub struct WhileStatementExtractor {
+pub struct ExtractWhileStatements {
     pub extracted: Vec<WhileStatement>,
 }
 
-impl WhileStatementExtractor {
-    pub fn extract_from<T: Node + ?Sized>(node: &T) -> Self {
-        let mut extractor: WhileStatementExtractor = Self::default();
+impl ExtractWhileStatements {
+    pub fn from<T: Node + ?Sized>(node: &T) -> Self {
+        let mut extractor: ExtractWhileStatements = Self::default();
         node.accept(&mut extractor).unwrap_or_default();
         extractor
     }
 }
 
-impl ASTConstVisitor for WhileStatementExtractor {
+impl ASTConstVisitor for ExtractWhileStatements {
     fn visit_while_statement(&mut self, node: &WhileStatement) -> Result<bool> {
         self.extracted.push(node.clone());
         Ok(true)

--- a/aderyn_core/src/context/browser/mod.rs
+++ b/aderyn_core/src/context/browser/mod.rs
@@ -1,3 +1,4 @@
 mod extractor;
-
+mod parent_seeker;
 pub use extractor::*;
+pub use parent_seeker::*;

--- a/aderyn_core/src/context/browser/mod.rs
+++ b/aderyn_core/src/context/browser/mod.rs
@@ -1,4 +1,4 @@
 mod extractor;
-mod parent_seeker;
+mod parents;
 pub use extractor::*;
-pub use parent_seeker::*;
+pub use parents::*;

--- a/aderyn_core/src/context/browser/parent_seeker.rs
+++ b/aderyn_core/src/context/browser/parent_seeker.rs
@@ -1,0 +1,116 @@
+use crate::{ast::*, context::loader::ContextLoader};
+
+pub trait SeekParent {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit>;
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition>;
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition>;
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition>;
+}
+
+// ArrayTypeName SeekParent allows us to finction an ArrayTypeName's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for ArrayTypeName {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.array_type_names.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.array_type_names.get(self).and_then(move |x| {
+            if x.contract_definition_id.is_none() {
+                return None;
+            }
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.array_type_names.get(self).and_then(move |x| {
+            if x.function_definition_id.is_none() {
+                return None;
+            }
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == x.function_definition_id
+                })
+        })
+    }
+
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.array_type_names.get(self).and_then(move |x| {
+            if x.modifier_definition_id.is_none() {
+                return None;
+            }
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == x.modifier_definition_id
+                })
+        })
+    }
+}
+
+// Assignment SeekParent allows us to finction an Assignment's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for Assignment {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.assignments.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.assignments.get(self).and_then(move |x| {
+            if x.contract_definition_id.is_none() {
+                return None;
+            }
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.assignments.get(self).and_then(move |x| {
+            if x.function_definition_id.is_none() {
+                return None;
+            }
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == x.function_definition_id
+                })
+        })
+    }
+
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.assignments.get(self).and_then(move |x| {
+            if x.modifier_definition_id.is_none() {
+                return None;
+            }
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == x.modifier_definition_id
+                })
+        })
+    }
+}

--- a/aderyn_core/src/context/browser/parent_seeker.rs
+++ b/aderyn_core/src/context/browser/parent_seeker.rs
@@ -1,4 +1,7 @@
-use crate::{ast::*, context::loader::ContextLoader};
+use crate::{
+    ast::*,
+    context::loader::{self, ContextLoader},
+};
 
 pub trait SeekParent {
     fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit>;
@@ -98,6 +101,2193 @@ impl SeekParent for Assignment {
                 .keys()
                 .find(|modifier_definition| {
                     Some(modifier_definition.id) == x.modifier_definition_id
+                })
+        })
+    }
+}
+
+// BinaryOperation SeekParent allows us to finction an BinaryOperation's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for BinaryOperation {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.binary_operations.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.binary_operations.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.binary_operations.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == x.function_definition_id
+                })
+        })
+    }
+
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.binary_operations.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == x.modifier_definition_id
+                })
+        })
+    }
+}
+
+// Block SeekParent allows us to finction an Block's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for Block {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.blocks.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.blocks.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.blocks.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == x.function_definition_id
+                })
+        })
+    }
+
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.blocks.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == x.modifier_definition_id
+                })
+        })
+    }
+}
+
+// Conditional SeekParent allows us to finction an Conditional's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for Conditional {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.conditionals.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.conditionals.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.conditionals.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == x.function_definition_id
+                })
+        })
+    }
+
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.conditionals.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == x.modifier_definition_id
+                })
+        })
+    }
+}
+
+// ContractDefinition SeekParent allows us to finction an ContractDefinition's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for ContractDefinition {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.contract_definitions.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+
+    fn contract_definition<'a>(
+        &self,
+        _loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
+        None
+    }
+
+    fn function_definition<'a>(
+        &self,
+        _loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
+        None
+    }
+
+    fn modifier_definition<'a>(
+        &self,
+        _loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
+        None
+    }
+}
+
+// ElementaryTypeName SeekParent allows us to finction an ElementaryTypeName's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for ElementaryTypeName {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.elementary_type_names.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.elementary_type_names.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.elementary_type_names.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == x.function_definition_id
+                })
+        })
+    }
+
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.elementary_type_names.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == x.modifier_definition_id
+                })
+        })
+    }
+}
+
+// ElementaryTypeNameExpression SeekParent allows us to finction an ElementaryTypeNameExpression's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for ElementaryTypeNameExpression {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader
+            .elementary_type_name_expressions
+            .get(self)
+            .and_then(move |x| {
+                loader
+                    .source_units
+                    .iter()
+                    .find(|source_unit| source_unit.id == x.source_unit_id)
+            })
+    }
+
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader
+            .elementary_type_name_expressions
+            .get(self)
+            .and_then(move |x| {
+                x.contract_definition_id?;
+                loader
+                    .contract_definitions
+                    .keys()
+                    .find(|contract_definition| {
+                        Some(contract_definition.id) == x.contract_definition_id
+                    })
+            })
+    }
+
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader
+            .elementary_type_name_expressions
+            .get(self)
+            .and_then(move |x| {
+                x.function_definition_id?;
+                loader
+                    .function_definitions
+                    .keys()
+                    .find(|function_definition| {
+                        Some(function_definition.id) == x.function_definition_id
+                    })
+            })
+    }
+
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader
+            .elementary_type_name_expressions
+            .get(self)
+            .and_then(move |x| {
+                x.modifier_definition_id?;
+                loader
+                    .modifier_definitions
+                    .keys()
+                    .find(|modifier_definition| {
+                        Some(modifier_definition.id) == x.modifier_definition_id
+                    })
+            })
+    }
+}
+
+// EmitStatement SeekParent allows us to finction an EmitStatement's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for EmitStatement {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.emit_statements.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.emit_statements.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.emit_statements.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == x.function_definition_id
+                })
+        })
+    }
+
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.emit_statements.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == x.modifier_definition_id
+                })
+        })
+    }
+}
+
+// EnumDefinition SeekParent allows us to finction an EnumDefinition's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for EnumDefinition {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.enum_definitions.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.enum_definitions.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+
+    fn function_definition<'a>(
+        &self,
+        _loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
+        None
+    }
+
+    fn modifier_definition<'a>(
+        &self,
+        _loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
+        None
+    }
+}
+
+// EnumValue SeekParent allows us to finction an EnumValue's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for EnumValue {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.enum_values.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.enum_values.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+
+    fn function_definition<'a>(
+        &self,
+        _loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
+        None
+    }
+
+    fn modifier_definition<'a>(
+        &self,
+        _loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
+        None
+    }
+}
+
+// EventDefinition SeekParent allows us to finction an EventDefinition's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for EventDefinition {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.event_definitions.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.event_definitions.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+
+    fn function_definition<'a>(
+        &self,
+        _loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
+        None
+    }
+
+    fn modifier_definition<'a>(
+        &self,
+        _loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
+        None
+    }
+}
+
+// ErrorDefinition SeekParent allows us to finction an ErrorDefinition's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for ErrorDefinition {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.error_definitions.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.error_definitions.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+
+    fn function_definition<'a>(
+        &self,
+        _loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
+        None
+    }
+
+    fn modifier_definition<'a>(
+        &self,
+        _loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
+        None
+    }
+}
+
+// ExpressionStatement SeekParent allows us to finction an ExpressionStatement's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for ExpressionStatement {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.expression_statements.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.expression_statements.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.expression_statements.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == x.function_definition_id
+                })
+        })
+    }
+
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.expression_statements.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == x.modifier_definition_id
+                })
+        })
+    }
+}
+
+// FunctionCall SeekParent allows us to finction an FunctionCall's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for FunctionCall {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.function_calls.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.function_calls.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.function_calls.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == x.function_definition_id
+                })
+        })
+    }
+
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.function_calls.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == x.modifier_definition_id
+                })
+        })
+    }
+}
+
+// FunctionCallOptions SeekParent allows us to finction an FunctionCallOptions' parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for FunctionCallOptions {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.function_call_options.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.function_call_options.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.function_call_options.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == x.function_definition_id
+                })
+        })
+    }
+
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.function_call_options.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == x.modifier_definition_id
+                })
+        })
+    }
+}
+
+// FunctionDefinition SeekParent allows us to finction an FunctionDefinition's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for FunctionDefinition {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.function_definitions.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.function_definitions.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+    fn function_definition<'a>(
+        &self,
+        _loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
+        None
+    }
+    fn modifier_definition<'a>(
+        &self,
+        _loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
+        None
+    }
+}
+
+// FunctionTypeName SeekParent allows us to finction an FunctionTypeName's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for FunctionTypeName {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.function_type_names.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.function_type_names.get(self).and_then(move |x| {
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.function_type_names.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == x.function_definition_id
+                })
+        })
+    }
+
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.function_type_names.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == x.modifier_definition_id
+                })
+        })
+    }
+}
+
+// ForStatement SeekParent allows us to finction an ForStatement's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for ForStatement {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.for_statements.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.for_statements.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.for_statements.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == x.function_definition_id
+                })
+        })
+    }
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.for_statements.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == x.modifier_definition_id
+                })
+        })
+    }
+}
+
+// Identifier SeekParent allows us to finction an Identifier's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for Identifier {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.identifiers.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.identifiers.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.identifiers.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == x.function_definition_id
+                })
+        })
+    }
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.identifiers.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == x.modifier_definition_id
+                })
+        })
+    }
+}
+
+// IdentifierPath SeekParent allows us to finction an IdentifierPath's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for IdentifierPath {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.identifier_paths.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.identifier_paths.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.identifier_paths.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == x.function_definition_id
+                })
+        })
+    }
+
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.identifier_paths.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == x.modifier_definition_id
+                })
+        })
+    }
+}
+
+// IfStatement SeekParent allows us to finction an IfStatement's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for IfStatement {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.if_statements.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.if_statements.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.if_statements.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == x.function_definition_id
+                })
+        })
+    }
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.if_statements.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == x.modifier_definition_id
+                })
+        })
+    }
+}
+
+// ImportDirective SeekParent allows us to finction an ImportDirective's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for ImportDirective {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.import_directives.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.import_directives.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.import_directives.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == x.function_definition_id
+                })
+        })
+    }
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.import_directives.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == x.modifier_definition_id
+                })
+        })
+    }
+}
+
+// IndexAccess SeekParent allows us to finction an IndexAccess's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for IndexAccess {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.index_accesses.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.index_accesses.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.index_accesses.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == x.function_definition_id
+                })
+        })
+    }
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.index_accesses.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == x.modifier_definition_id
+                })
+        })
+    }
+}
+
+// IndexRangeAccess SeekParent allows us to finction an IndexRangeAccess's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for IndexRangeAccess {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.index_range_accesses.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.index_range_accesses.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.index_range_accesses.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == x.function_definition_id
+                })
+        })
+    }
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.index_range_accesses.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == x.modifier_definition_id
+                })
+        })
+    }
+}
+
+// InheritanceSpecifier SeekParent allows us to finction an InheritanceSpecifier's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for InheritanceSpecifier {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.inheritance_specifiers.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.inheritance_specifiers.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+    fn function_definition<'a>(
+        &self,
+        _loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
+        None
+    }
+    fn modifier_definition<'a>(
+        &self,
+        _loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
+        None
+    }
+}
+
+// InlineAssembly SeekParent allows us to finction an InlineAssembly's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for InlineAssembly {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.inline_assemblies.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.inline_assemblies.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.inline_assemblies.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == x.function_definition_id
+                })
+        })
+    }
+
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.inline_assemblies.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == x.modifier_definition_id
+                })
+        })
+    }
+}
+
+// Literal SeekParent allows us to finction an Literal's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for Literal {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.literals.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.literals.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.literals.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == x.function_definition_id
+                })
+        })
+    }
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.literals.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == x.modifier_definition_id
+                })
+        })
+    }
+}
+
+// MemberAccess SeekParent allows us to finction an MemberAccess's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for MemberAccess {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.member_accesses.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.member_accesses.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.member_accesses.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == x.function_definition_id
+                })
+        })
+    }
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.member_accesses.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == x.modifier_definition_id
+                })
+        })
+    }
+}
+
+// NewExpression SeekParent allows us to finction an NewExpression's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for NewExpression {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.new_expressions.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.new_expressions.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.new_expressions.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == x.function_definition_id
+                })
+        })
+    }
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.new_expressions.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == x.modifier_definition_id
+                })
+        })
+    }
+}
+
+// Mapping SeekParent allows us to finction an Mapping's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for Mapping {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.mappings.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.mappings.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.mappings.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == x.function_definition_id
+                })
+        })
+    }
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.mappings.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == x.modifier_definition_id
+                })
+        })
+    }
+}
+
+// ModifierDefinition SeekParent allows us to finction an ModifierDefinition's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for ModifierDefinition {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.modifier_definitions.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.modifier_definitions.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.modifier_definitions.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == x.function_definition_id
+                })
+        })
+    }
+    fn modifier_definition<'a>(
+        &self,
+        _loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
+        None
+    }
+}
+
+// ModifierInvocation SeekParent allows us to finction an ModifierInvocation's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for ModifierInvocation {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.modifier_invocations.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.modifier_invocations.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.modifier_invocations.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == x.function_definition_id
+                })
+        })
+    }
+    fn modifier_definition<'a>(
+        &self,
+        _loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
+        None
+    }
+}
+
+// OverrideSpecifier SeekParent allows us to finction an OverrideSpecifier's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for OverrideSpecifier {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.override_specifiers.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.override_specifiers.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.override_specifiers.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == x.function_definition_id
+                })
+        })
+    }
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.override_specifiers.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == x.modifier_definition_id
+                })
+        })
+    }
+}
+
+// ParameterList SeekParent allows us to finction an ParameterList's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for ParameterList {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.parameter_lists.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.parameter_lists.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.parameter_lists.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == x.function_definition_id
+                })
+        })
+    }
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.parameter_lists.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == x.modifier_definition_id
+                })
+        })
+    }
+}
+
+// PragmaDirective SeekParent allows us to finction an PragmaDirective's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for PragmaDirective {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.pragma_directives.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+    fn contract_definition<'a>(
+        &self,
+        _loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
+        None
+    }
+    fn function_definition<'a>(
+        &self,
+        _loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
+        None
+    }
+    fn modifier_definition<'a>(
+        &self,
+        _loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
+        None
+    }
+}
+
+// Return SeekParent allows us to finction an Return's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for Return {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.returns.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.returns.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.returns.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == x.function_definition_id
+                })
+        })
+    }
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.returns.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == x.modifier_definition_id
+                })
+        })
+    }
+}
+
+// RevertStatement SeekParent allows us to finction an RevertStatement's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for RevertStatement {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.revert_statements.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.revert_statements.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.revert_statements.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == x.function_definition_id
+                })
+        })
+    }
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.revert_statements.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == x.modifier_definition_id
+                })
+        })
+    }
+}
+
+// StructDefinition SeekParent allows us to finction an StructDefinition's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for StructDefinition {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.struct_definitions.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.struct_definitions.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.struct_definitions.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == x.function_definition_id
+                })
+        })
+    }
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.struct_definitions.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == x.modifier_definition_id
+                })
+        })
+    }
+}
+
+// StructuredDocumentation SeekParent allows us to finction an StructuredDocumentation's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for StructuredDocumentation {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader
+            .structured_documentations
+            .get(self)
+            .and_then(move |x| {
+                loader
+                    .source_units
+                    .iter()
+                    .find(|source_unit| source_unit.id == x.source_unit_id)
+            })
+    }
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader
+            .structured_documentations
+            .get(self)
+            .and_then(move |x| {
+                x.contract_definition_id?;
+                loader
+                    .contract_definitions
+                    .keys()
+                    .find(|contract_definition| {
+                        Some(contract_definition.id) == x.contract_definition_id
+                    })
+            })
+    }
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader
+            .structured_documentations
+            .get(self)
+            .and_then(move |x| {
+                x.function_definition_id?;
+                loader
+                    .function_definitions
+                    .keys()
+                    .find(|function_definition| {
+                        Some(function_definition.id) == x.function_definition_id
+                    })
+            })
+    }
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader
+            .structured_documentations
+            .get(self)
+            .and_then(move |x| {
+                x.modifier_definition_id?;
+                loader
+                    .modifier_definitions
+                    .keys()
+                    .find(|modifier_definition| {
+                        Some(modifier_definition.id) == x.modifier_definition_id
+                    })
+            })
+    }
+}
+
+// TryStatement SeekParent allows us to finction an TryStatement's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for TryStatement {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.try_statements.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.try_statements.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == x.contract_definition_id
+                })
+        })
+    }
+
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.try_statements.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == x.function_definition_id
+                })
+        })
+    }
+
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.try_statements.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == x.modifier_definition_id
+                })
+        })
+    }
+}
+
+// TryCatchClause SeekParent allows us to finction an TryCatchClause's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for TryCatchClause {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.try_catch_clauses.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == x.source_unit_id)
+        })
+    }
+
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.try_catch_clauses.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == (x.contract_definition_id)
+                })
+        })
+    }
+
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.try_catch_clauses.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == (x.function_definition_id)
+                })
+        })
+    }
+
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.try_catch_clauses.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == (x.modifier_definition_id)
+                })
+        })
+    }
+}
+
+// TupleExpression SeekParent allows us to finction an TupleExpression's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for TupleExpression {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.tuple_expressions.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == (x.source_unit_id))
+        })
+    }
+
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.tuple_expressions.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == (x.contract_definition_id)
+                })
+        })
+    }
+
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.tuple_expressions.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == (x.function_definition_id)
+                })
+        })
+    }
+
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.tuple_expressions.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == (x.modifier_definition_id)
+                })
+        })
+    }
+}
+
+// UnaryOperation SeekParent allows us to finction an UnaryOperation's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for UnaryOperation {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.unary_operations.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == (x.source_unit_id))
+        })
+    }
+
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.unary_operations.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == (x.contract_definition_id)
+                })
+        })
+    }
+
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.unary_operations.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == (x.function_definition_id)
+                })
+        })
+    }
+
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.unary_operations.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == (x.modifier_definition_id)
+                })
+        })
+    }
+}
+
+// UserDefinedTypeName SeekParent allows us to finction an UserDefinedTypeName's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for UserDefinedTypeName {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.user_defined_type_names.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == (x.source_unit_id))
+        })
+    }
+
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.user_defined_type_names.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == (x.contract_definition_id)
+                })
+        })
+    }
+
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.user_defined_type_names.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == (x.function_definition_id)
+                })
+        })
+    }
+
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.user_defined_type_names.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == (x.modifier_definition_id)
+                })
+        })
+    }
+}
+
+// UsingStatement SeekParent allows us to finction an UsingStatement's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for UserDefinedValueTypeDefinition {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader
+            .user_defined_value_type_definitions
+            .get(self)
+            .and_then(move |x| {
+                loader
+                    .source_units
+                    .iter()
+                    .find(|source_unit| source_unit.id == (x.source_unit_id))
+            })
+    }
+
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader
+            .user_defined_value_type_definitions
+            .get(self)
+            .and_then(move |x| {
+                x.contract_definition_id?;
+                loader
+                    .contract_definitions
+                    .keys()
+                    .find(|contract_definition| {
+                        Some(contract_definition.id) == (x.contract_definition_id)
+                    })
+            })
+    }
+
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader
+            .user_defined_value_type_definitions
+            .get(self)
+            .and_then(move |x| {
+                x.function_definition_id?;
+                loader
+                    .function_definitions
+                    .keys()
+                    .find(|function_definition| {
+                        Some(function_definition.id) == (x.function_definition_id)
+                    })
+            })
+    }
+
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader
+            .user_defined_value_type_definitions
+            .get(self)
+            .and_then(move |x| {
+                x.modifier_definition_id?;
+                loader
+                    .modifier_definitions
+                    .keys()
+                    .find(|modifier_definition| {
+                        Some(modifier_definition.id) == (x.modifier_definition_id)
+                    })
+            })
+    }
+}
+
+// UsingForDirective SeekParent allows us to finction an UsingForDirective's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for UsingForDirective {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.using_for_directives.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == (x.source_unit_id))
+        })
+    }
+
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.using_for_directives.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == (x.contract_definition_id)
+                })
+        })
+    }
+
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.using_for_directives.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == (x.function_definition_id)
+                })
+        })
+    }
+
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.using_for_directives.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == (x.modifier_definition_id)
+                })
+        })
+    }
+}
+
+// VariableDeclaration SeekParent allows us to finction an VariableDeclaration's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for VariableDeclaration {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.variable_declarations.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == (x.source_unit_id))
+        })
+    }
+
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.variable_declarations.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == (x.contract_definition_id)
+                })
+        })
+    }
+
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.variable_declarations.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == (x.function_definition_id)
+                })
+        })
+    }
+
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.variable_declarations.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == (x.modifier_definition_id)
+                })
+        })
+    }
+}
+
+// VariableDeclarationStatement SeekParent allows us to finction an VariableDeclarationStatement's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for VariableDeclarationStatement {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader
+            .variable_declaration_statements
+            .get(self)
+            .and_then(move |x| {
+                loader
+                    .source_units
+                    .iter()
+                    .find(|source_unit| source_unit.id == (x.source_unit_id))
+            })
+    }
+
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader
+            .variable_declaration_statements
+            .get(self)
+            .and_then(move |x| {
+                x.contract_definition_id?;
+                loader
+                    .contract_definitions
+                    .keys()
+                    .find(|contract_definition| {
+                        Some(contract_definition.id) == (x.contract_definition_id)
+                    })
+            })
+    }
+
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader
+            .variable_declaration_statements
+            .get(self)
+            .and_then(move |x| {
+                x.function_definition_id?;
+                loader
+                    .function_definitions
+                    .keys()
+                    .find(|function_definition| {
+                        Some(function_definition.id) == (x.function_definition_id)
+                    })
+            })
+    }
+
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader
+            .variable_declaration_statements
+            .get(self)
+            .and_then(move |x| {
+                x.modifier_definition_id?;
+                loader
+                    .modifier_definitions
+                    .keys()
+                    .find(|modifier_definition| {
+                        Some(modifier_definition.id) == (x.modifier_definition_id)
+                    })
+            })
+    }
+}
+
+// WhileStatement SeekParent allows us to finction an WhileStatement's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl SeekParent for WhileStatement {
+    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+        loader.while_statements.get(self).and_then(move |x| {
+            loader
+                .source_units
+                .iter()
+                .find(|source_unit| source_unit.id == (x.source_unit_id))
+        })
+    }
+
+    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+        loader.while_statements.get(self).and_then(move |x| {
+            x.contract_definition_id?;
+            loader
+                .contract_definitions
+                .keys()
+                .find(|contract_definition| {
+                    Some(contract_definition.id) == (x.contract_definition_id)
+                })
+        })
+    }
+
+    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+        loader.while_statements.get(self).and_then(move |x| {
+            x.function_definition_id?;
+            loader
+                .function_definitions
+                .keys()
+                .find(|function_definition| {
+                    Some(function_definition.id) == (x.function_definition_id)
+                })
+        })
+    }
+
+    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+        loader.while_statements.get(self).and_then(move |x| {
+            x.modifier_definition_id?;
+            loader
+                .modifier_definitions
+                .keys()
+                .find(|modifier_definition| {
+                    Some(modifier_definition.id) == (x.modifier_definition_id)
                 })
         })
     }

--- a/aderyn_core/src/context/browser/parent_seeker.rs
+++ b/aderyn_core/src/context/browser/parent_seeker.rs
@@ -20,9 +20,7 @@ impl SeekParent for ArrayTypeName {
 
     fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
         loader.array_type_names.get(self).and_then(move |x| {
-            if x.contract_definition_id.is_none() {
-                return None;
-            }
+            x.contract_definition_id?;
             loader
                 .contract_definitions
                 .keys()
@@ -34,9 +32,7 @@ impl SeekParent for ArrayTypeName {
 
     fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
         loader.array_type_names.get(self).and_then(move |x| {
-            if x.function_definition_id.is_none() {
-                return None;
-            }
+            x.function_definition_id?;
             loader
                 .function_definitions
                 .keys()
@@ -48,9 +44,7 @@ impl SeekParent for ArrayTypeName {
 
     fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
         loader.array_type_names.get(self).and_then(move |x| {
-            if x.modifier_definition_id.is_none() {
-                return None;
-            }
+            x.modifier_definition_id?;
             loader
                 .modifier_definitions
                 .keys()
@@ -74,9 +68,7 @@ impl SeekParent for Assignment {
 
     fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
         loader.assignments.get(self).and_then(move |x| {
-            if x.contract_definition_id.is_none() {
-                return None;
-            }
+            x.contract_definition_id?;
             loader
                 .contract_definitions
                 .keys()
@@ -88,9 +80,7 @@ impl SeekParent for Assignment {
 
     fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
         loader.assignments.get(self).and_then(move |x| {
-            if x.function_definition_id.is_none() {
-                return None;
-            }
+            x.function_definition_id?;
             loader
                 .function_definitions
                 .keys()
@@ -102,9 +92,7 @@ impl SeekParent for Assignment {
 
     fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
         loader.assignments.get(self).and_then(move |x| {
-            if x.modifier_definition_id.is_none() {
-                return None;
-            }
+            x.modifier_definition_id?;
             loader
                 .modifier_definitions
                 .keys()

--- a/aderyn_core/src/context/browser/parent_seeker.rs
+++ b/aderyn_core/src/context/browser/parent_seeker.rs
@@ -1,7 +1,4 @@
-use crate::{
-    ast::*,
-    context::loader::{self, ContextLoader},
-};
+use crate::{ast::*, context::loader::ContextLoader};
 
 pub trait SeekParent {
     fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit>;
@@ -1855,7 +1852,7 @@ impl SeekParent for TryCatchClause {
                 .contract_definitions
                 .keys()
                 .find(|contract_definition| {
-                    Some(contract_definition.id) == (x.contract_definition_id)
+                    Some(contract_definition.id) == x.contract_definition_id
                 })
         })
     }
@@ -1867,7 +1864,7 @@ impl SeekParent for TryCatchClause {
                 .function_definitions
                 .keys()
                 .find(|function_definition| {
-                    Some(function_definition.id) == (x.function_definition_id)
+                    Some(function_definition.id) == x.function_definition_id
                 })
         })
     }
@@ -1879,7 +1876,7 @@ impl SeekParent for TryCatchClause {
                 .modifier_definitions
                 .keys()
                 .find(|modifier_definition| {
-                    Some(modifier_definition.id) == (x.modifier_definition_id)
+                    Some(modifier_definition.id) == x.modifier_definition_id
                 })
         })
     }
@@ -1892,7 +1889,7 @@ impl SeekParent for TupleExpression {
             loader
                 .source_units
                 .iter()
-                .find(|source_unit| source_unit.id == (x.source_unit_id))
+                .find(|source_unit| source_unit.id == x.source_unit_id)
         })
     }
 
@@ -1903,7 +1900,7 @@ impl SeekParent for TupleExpression {
                 .contract_definitions
                 .keys()
                 .find(|contract_definition| {
-                    Some(contract_definition.id) == (x.contract_definition_id)
+                    Some(contract_definition.id) == x.contract_definition_id
                 })
         })
     }
@@ -1915,7 +1912,7 @@ impl SeekParent for TupleExpression {
                 .function_definitions
                 .keys()
                 .find(|function_definition| {
-                    Some(function_definition.id) == (x.function_definition_id)
+                    Some(function_definition.id) == x.function_definition_id
                 })
         })
     }
@@ -1927,7 +1924,7 @@ impl SeekParent for TupleExpression {
                 .modifier_definitions
                 .keys()
                 .find(|modifier_definition| {
-                    Some(modifier_definition.id) == (x.modifier_definition_id)
+                    Some(modifier_definition.id) == x.modifier_definition_id
                 })
         })
     }
@@ -1940,7 +1937,7 @@ impl SeekParent for UnaryOperation {
             loader
                 .source_units
                 .iter()
-                .find(|source_unit| source_unit.id == (x.source_unit_id))
+                .find(|source_unit| source_unit.id == x.source_unit_id)
         })
     }
 
@@ -1951,7 +1948,7 @@ impl SeekParent for UnaryOperation {
                 .contract_definitions
                 .keys()
                 .find(|contract_definition| {
-                    Some(contract_definition.id) == (x.contract_definition_id)
+                    Some(contract_definition.id) == x.contract_definition_id
                 })
         })
     }
@@ -1963,7 +1960,7 @@ impl SeekParent for UnaryOperation {
                 .function_definitions
                 .keys()
                 .find(|function_definition| {
-                    Some(function_definition.id) == (x.function_definition_id)
+                    Some(function_definition.id) == x.function_definition_id
                 })
         })
     }
@@ -1975,7 +1972,7 @@ impl SeekParent for UnaryOperation {
                 .modifier_definitions
                 .keys()
                 .find(|modifier_definition| {
-                    Some(modifier_definition.id) == (x.modifier_definition_id)
+                    Some(modifier_definition.id) == x.modifier_definition_id
                 })
         })
     }
@@ -1988,7 +1985,7 @@ impl SeekParent for UserDefinedTypeName {
             loader
                 .source_units
                 .iter()
-                .find(|source_unit| source_unit.id == (x.source_unit_id))
+                .find(|source_unit| source_unit.id == x.source_unit_id)
         })
     }
 
@@ -1999,7 +1996,7 @@ impl SeekParent for UserDefinedTypeName {
                 .contract_definitions
                 .keys()
                 .find(|contract_definition| {
-                    Some(contract_definition.id) == (x.contract_definition_id)
+                    Some(contract_definition.id) == x.contract_definition_id
                 })
         })
     }
@@ -2011,7 +2008,7 @@ impl SeekParent for UserDefinedTypeName {
                 .function_definitions
                 .keys()
                 .find(|function_definition| {
-                    Some(function_definition.id) == (x.function_definition_id)
+                    Some(function_definition.id) == x.function_definition_id
                 })
         })
     }
@@ -2023,7 +2020,7 @@ impl SeekParent for UserDefinedTypeName {
                 .modifier_definitions
                 .keys()
                 .find(|modifier_definition| {
-                    Some(modifier_definition.id) == (x.modifier_definition_id)
+                    Some(modifier_definition.id) == x.modifier_definition_id
                 })
         })
     }
@@ -2039,7 +2036,7 @@ impl SeekParent for UserDefinedValueTypeDefinition {
                 loader
                     .source_units
                     .iter()
-                    .find(|source_unit| source_unit.id == (x.source_unit_id))
+                    .find(|source_unit| source_unit.id == x.source_unit_id)
             })
     }
 
@@ -2053,7 +2050,7 @@ impl SeekParent for UserDefinedValueTypeDefinition {
                     .contract_definitions
                     .keys()
                     .find(|contract_definition| {
-                        Some(contract_definition.id) == (x.contract_definition_id)
+                        Some(contract_definition.id) == x.contract_definition_id
                     })
             })
     }
@@ -2068,7 +2065,7 @@ impl SeekParent for UserDefinedValueTypeDefinition {
                     .function_definitions
                     .keys()
                     .find(|function_definition| {
-                        Some(function_definition.id) == (x.function_definition_id)
+                        Some(function_definition.id) == x.function_definition_id
                     })
             })
     }
@@ -2083,7 +2080,7 @@ impl SeekParent for UserDefinedValueTypeDefinition {
                     .modifier_definitions
                     .keys()
                     .find(|modifier_definition| {
-                        Some(modifier_definition.id) == (x.modifier_definition_id)
+                        Some(modifier_definition.id) == x.modifier_definition_id
                     })
             })
     }
@@ -2096,7 +2093,7 @@ impl SeekParent for UsingForDirective {
             loader
                 .source_units
                 .iter()
-                .find(|source_unit| source_unit.id == (x.source_unit_id))
+                .find(|source_unit| source_unit.id == x.source_unit_id)
         })
     }
 
@@ -2107,7 +2104,7 @@ impl SeekParent for UsingForDirective {
                 .contract_definitions
                 .keys()
                 .find(|contract_definition| {
-                    Some(contract_definition.id) == (x.contract_definition_id)
+                    Some(contract_definition.id) == x.contract_definition_id
                 })
         })
     }
@@ -2119,7 +2116,7 @@ impl SeekParent for UsingForDirective {
                 .function_definitions
                 .keys()
                 .find(|function_definition| {
-                    Some(function_definition.id) == (x.function_definition_id)
+                    Some(function_definition.id) == x.function_definition_id
                 })
         })
     }
@@ -2131,7 +2128,7 @@ impl SeekParent for UsingForDirective {
                 .modifier_definitions
                 .keys()
                 .find(|modifier_definition| {
-                    Some(modifier_definition.id) == (x.modifier_definition_id)
+                    Some(modifier_definition.id) == x.modifier_definition_id
                 })
         })
     }
@@ -2144,7 +2141,7 @@ impl SeekParent for VariableDeclaration {
             loader
                 .source_units
                 .iter()
-                .find(|source_unit| source_unit.id == (x.source_unit_id))
+                .find(|source_unit| source_unit.id == x.source_unit_id)
         })
     }
 
@@ -2155,7 +2152,7 @@ impl SeekParent for VariableDeclaration {
                 .contract_definitions
                 .keys()
                 .find(|contract_definition| {
-                    Some(contract_definition.id) == (x.contract_definition_id)
+                    Some(contract_definition.id) == x.contract_definition_id
                 })
         })
     }
@@ -2167,7 +2164,7 @@ impl SeekParent for VariableDeclaration {
                 .function_definitions
                 .keys()
                 .find(|function_definition| {
-                    Some(function_definition.id) == (x.function_definition_id)
+                    Some(function_definition.id) == x.function_definition_id
                 })
         })
     }
@@ -2179,7 +2176,7 @@ impl SeekParent for VariableDeclaration {
                 .modifier_definitions
                 .keys()
                 .find(|modifier_definition| {
-                    Some(modifier_definition.id) == (x.modifier_definition_id)
+                    Some(modifier_definition.id) == x.modifier_definition_id
                 })
         })
     }
@@ -2195,7 +2192,7 @@ impl SeekParent for VariableDeclarationStatement {
                 loader
                     .source_units
                     .iter()
-                    .find(|source_unit| source_unit.id == (x.source_unit_id))
+                    .find(|source_unit| source_unit.id == x.source_unit_id)
             })
     }
 
@@ -2209,7 +2206,7 @@ impl SeekParent for VariableDeclarationStatement {
                     .contract_definitions
                     .keys()
                     .find(|contract_definition| {
-                        Some(contract_definition.id) == (x.contract_definition_id)
+                        Some(contract_definition.id) == x.contract_definition_id
                     })
             })
     }
@@ -2224,7 +2221,7 @@ impl SeekParent for VariableDeclarationStatement {
                     .function_definitions
                     .keys()
                     .find(|function_definition| {
-                        Some(function_definition.id) == (x.function_definition_id)
+                        Some(function_definition.id) == x.function_definition_id
                     })
             })
     }
@@ -2239,7 +2236,7 @@ impl SeekParent for VariableDeclarationStatement {
                     .modifier_definitions
                     .keys()
                     .find(|modifier_definition| {
-                        Some(modifier_definition.id) == (x.modifier_definition_id)
+                        Some(modifier_definition.id) == x.modifier_definition_id
                     })
             })
     }
@@ -2252,7 +2249,7 @@ impl SeekParent for WhileStatement {
             loader
                 .source_units
                 .iter()
-                .find(|source_unit| source_unit.id == (x.source_unit_id))
+                .find(|source_unit| source_unit.id == x.source_unit_id)
         })
     }
 
@@ -2263,7 +2260,7 @@ impl SeekParent for WhileStatement {
                 .contract_definitions
                 .keys()
                 .find(|contract_definition| {
-                    Some(contract_definition.id) == (x.contract_definition_id)
+                    Some(contract_definition.id) == x.contract_definition_id
                 })
         })
     }
@@ -2275,7 +2272,7 @@ impl SeekParent for WhileStatement {
                 .function_definitions
                 .keys()
                 .find(|function_definition| {
-                    Some(function_definition.id) == (x.function_definition_id)
+                    Some(function_definition.id) == x.function_definition_id
                 })
         })
     }
@@ -2287,7 +2284,7 @@ impl SeekParent for WhileStatement {
                 .modifier_definitions
                 .keys()
                 .find(|modifier_definition| {
-                    Some(modifier_definition.id) == (x.modifier_definition_id)
+                    Some(modifier_definition.id) == x.modifier_definition_id
                 })
         })
     }

--- a/aderyn_core/src/context/browser/parents.rs
+++ b/aderyn_core/src/context/browser/parents.rs
@@ -1,15 +1,20 @@
 use crate::{ast::*, context::loader::ContextLoader};
 
+/// GetParent allows us to finction an ASTNode's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
 pub trait GetParent {
+    /// Get the parent SourceUnit of an ASTNode
     fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit>;
+    /// Get the parent ContractDefinition of an ASTNode
     fn contract_definition_of<'a>(
         &self,
         loader: &'a ContextLoader,
     ) -> Option<&'a ContractDefinition>;
+    /// Get the parent FunctionDefinition of an ASTNode
     fn function_definition_of<'a>(
         &self,
         loader: &'a ContextLoader,
     ) -> Option<&'a FunctionDefinition>;
+    /// Get the parent ModifierDefinition of an ASTNode
     fn modifier_definition_of<'a>(
         &self,
         loader: &'a ContextLoader,

--- a/aderyn_core/src/context/browser/parents.rs
+++ b/aderyn_core/src/context/browser/parents.rs
@@ -1,15 +1,24 @@
 use crate::{ast::*, context::loader::ContextLoader};
 
-pub trait SeekParent {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit>;
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition>;
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition>;
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition>;
+pub trait GetParent {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit>;
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition>;
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition>;
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition>;
 }
 
-// ArrayTypeName SeekParent allows us to finction an ArrayTypeName's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for ArrayTypeName {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// ArrayTypeName GetParent allows us to finction an ArrayTypeName's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for ArrayTypeName {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.array_type_names.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -18,7 +27,10 @@ impl SeekParent for ArrayTypeName {
         })
     }
 
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.array_type_names.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -30,7 +42,10 @@ impl SeekParent for ArrayTypeName {
         })
     }
 
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.array_type_names.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -42,7 +57,10 @@ impl SeekParent for ArrayTypeName {
         })
     }
 
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.array_type_names.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -55,9 +73,9 @@ impl SeekParent for ArrayTypeName {
     }
 }
 
-// Assignment SeekParent allows us to finction an Assignment's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for Assignment {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// Assignment GetParent allows us to finction an Assignment's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for Assignment {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.assignments.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -66,7 +84,10 @@ impl SeekParent for Assignment {
         })
     }
 
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.assignments.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -78,7 +99,10 @@ impl SeekParent for Assignment {
         })
     }
 
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.assignments.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -90,7 +114,10 @@ impl SeekParent for Assignment {
         })
     }
 
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.assignments.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -103,9 +130,9 @@ impl SeekParent for Assignment {
     }
 }
 
-// BinaryOperation SeekParent allows us to finction an BinaryOperation's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for BinaryOperation {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// BinaryOperation GetParent allows us to finction an BinaryOperation's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for BinaryOperation {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.binary_operations.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -114,7 +141,10 @@ impl SeekParent for BinaryOperation {
         })
     }
 
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.binary_operations.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -126,7 +156,10 @@ impl SeekParent for BinaryOperation {
         })
     }
 
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.binary_operations.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -138,7 +171,10 @@ impl SeekParent for BinaryOperation {
         })
     }
 
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.binary_operations.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -151,9 +187,9 @@ impl SeekParent for BinaryOperation {
     }
 }
 
-// Block SeekParent allows us to finction an Block's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for Block {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// Block GetParent allows us to finction an Block's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for Block {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.blocks.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -162,7 +198,10 @@ impl SeekParent for Block {
         })
     }
 
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.blocks.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -174,7 +213,10 @@ impl SeekParent for Block {
         })
     }
 
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.blocks.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -186,7 +228,10 @@ impl SeekParent for Block {
         })
     }
 
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.blocks.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -199,9 +244,9 @@ impl SeekParent for Block {
     }
 }
 
-// Conditional SeekParent allows us to finction an Conditional's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for Conditional {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// Conditional GetParent allows us to finction an Conditional's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for Conditional {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.conditionals.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -210,7 +255,10 @@ impl SeekParent for Conditional {
         })
     }
 
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.conditionals.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -222,7 +270,10 @@ impl SeekParent for Conditional {
         })
     }
 
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.conditionals.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -234,7 +285,10 @@ impl SeekParent for Conditional {
         })
     }
 
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.conditionals.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -247,9 +301,9 @@ impl SeekParent for Conditional {
     }
 }
 
-// ContractDefinition SeekParent allows us to finction an ContractDefinition's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for ContractDefinition {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// ContractDefinition GetParent allows us to finction an ContractDefinition's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for ContractDefinition {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.contract_definitions.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -258,21 +312,21 @@ impl SeekParent for ContractDefinition {
         })
     }
 
-    fn contract_definition<'a>(
+    fn contract_definition_of<'a>(
         &self,
         _loader: &'a ContextLoader,
     ) -> Option<&'a ContractDefinition> {
         None
     }
 
-    fn function_definition<'a>(
+    fn function_definition_of<'a>(
         &self,
         _loader: &'a ContextLoader,
     ) -> Option<&'a FunctionDefinition> {
         None
     }
 
-    fn modifier_definition<'a>(
+    fn modifier_definition_of<'a>(
         &self,
         _loader: &'a ContextLoader,
     ) -> Option<&'a ModifierDefinition> {
@@ -280,9 +334,9 @@ impl SeekParent for ContractDefinition {
     }
 }
 
-// ElementaryTypeName SeekParent allows us to finction an ElementaryTypeName's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for ElementaryTypeName {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// ElementaryTypeName GetParent allows us to finction an ElementaryTypeName's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for ElementaryTypeName {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.elementary_type_names.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -291,7 +345,10 @@ impl SeekParent for ElementaryTypeName {
         })
     }
 
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.elementary_type_names.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -303,7 +360,10 @@ impl SeekParent for ElementaryTypeName {
         })
     }
 
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.elementary_type_names.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -315,7 +375,10 @@ impl SeekParent for ElementaryTypeName {
         })
     }
 
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.elementary_type_names.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -328,9 +391,9 @@ impl SeekParent for ElementaryTypeName {
     }
 }
 
-// ElementaryTypeNameExpression SeekParent allows us to finction an ElementaryTypeNameExpression's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for ElementaryTypeNameExpression {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// ElementaryTypeNameExpression GetParent allows us to finction an ElementaryTypeNameExpression's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for ElementaryTypeNameExpression {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader
             .elementary_type_name_expressions
             .get(self)
@@ -342,7 +405,10 @@ impl SeekParent for ElementaryTypeNameExpression {
             })
     }
 
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader
             .elementary_type_name_expressions
             .get(self)
@@ -357,7 +423,10 @@ impl SeekParent for ElementaryTypeNameExpression {
             })
     }
 
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader
             .elementary_type_name_expressions
             .get(self)
@@ -372,7 +441,10 @@ impl SeekParent for ElementaryTypeNameExpression {
             })
     }
 
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader
             .elementary_type_name_expressions
             .get(self)
@@ -388,9 +460,9 @@ impl SeekParent for ElementaryTypeNameExpression {
     }
 }
 
-// EmitStatement SeekParent allows us to finction an EmitStatement's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for EmitStatement {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// EmitStatement GetParent allows us to finction an EmitStatement's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for EmitStatement {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.emit_statements.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -399,7 +471,10 @@ impl SeekParent for EmitStatement {
         })
     }
 
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.emit_statements.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -411,7 +486,10 @@ impl SeekParent for EmitStatement {
         })
     }
 
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.emit_statements.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -423,7 +501,10 @@ impl SeekParent for EmitStatement {
         })
     }
 
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.emit_statements.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -436,9 +517,9 @@ impl SeekParent for EmitStatement {
     }
 }
 
-// EnumDefinition SeekParent allows us to finction an EnumDefinition's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for EnumDefinition {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// EnumDefinition GetParent allows us to finction an EnumDefinition's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for EnumDefinition {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.enum_definitions.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -447,7 +528,10 @@ impl SeekParent for EnumDefinition {
         })
     }
 
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.enum_definitions.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -459,14 +543,14 @@ impl SeekParent for EnumDefinition {
         })
     }
 
-    fn function_definition<'a>(
+    fn function_definition_of<'a>(
         &self,
         _loader: &'a ContextLoader,
     ) -> Option<&'a FunctionDefinition> {
         None
     }
 
-    fn modifier_definition<'a>(
+    fn modifier_definition_of<'a>(
         &self,
         _loader: &'a ContextLoader,
     ) -> Option<&'a ModifierDefinition> {
@@ -474,9 +558,9 @@ impl SeekParent for EnumDefinition {
     }
 }
 
-// EnumValue SeekParent allows us to finction an EnumValue's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for EnumValue {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// EnumValue GetParent allows us to finction an EnumValue's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for EnumValue {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.enum_values.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -485,7 +569,10 @@ impl SeekParent for EnumValue {
         })
     }
 
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.enum_values.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -497,14 +584,14 @@ impl SeekParent for EnumValue {
         })
     }
 
-    fn function_definition<'a>(
+    fn function_definition_of<'a>(
         &self,
         _loader: &'a ContextLoader,
     ) -> Option<&'a FunctionDefinition> {
         None
     }
 
-    fn modifier_definition<'a>(
+    fn modifier_definition_of<'a>(
         &self,
         _loader: &'a ContextLoader,
     ) -> Option<&'a ModifierDefinition> {
@@ -512,9 +599,9 @@ impl SeekParent for EnumValue {
     }
 }
 
-// EventDefinition SeekParent allows us to finction an EventDefinition's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for EventDefinition {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// EventDefinition GetParent allows us to finction an EventDefinition's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for EventDefinition {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.event_definitions.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -523,7 +610,10 @@ impl SeekParent for EventDefinition {
         })
     }
 
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.event_definitions.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -535,14 +625,14 @@ impl SeekParent for EventDefinition {
         })
     }
 
-    fn function_definition<'a>(
+    fn function_definition_of<'a>(
         &self,
         _loader: &'a ContextLoader,
     ) -> Option<&'a FunctionDefinition> {
         None
     }
 
-    fn modifier_definition<'a>(
+    fn modifier_definition_of<'a>(
         &self,
         _loader: &'a ContextLoader,
     ) -> Option<&'a ModifierDefinition> {
@@ -550,9 +640,9 @@ impl SeekParent for EventDefinition {
     }
 }
 
-// ErrorDefinition SeekParent allows us to finction an ErrorDefinition's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for ErrorDefinition {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// ErrorDefinition GetParent allows us to finction an ErrorDefinition's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for ErrorDefinition {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.error_definitions.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -561,7 +651,10 @@ impl SeekParent for ErrorDefinition {
         })
     }
 
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.error_definitions.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -573,14 +666,14 @@ impl SeekParent for ErrorDefinition {
         })
     }
 
-    fn function_definition<'a>(
+    fn function_definition_of<'a>(
         &self,
         _loader: &'a ContextLoader,
     ) -> Option<&'a FunctionDefinition> {
         None
     }
 
-    fn modifier_definition<'a>(
+    fn modifier_definition_of<'a>(
         &self,
         _loader: &'a ContextLoader,
     ) -> Option<&'a ModifierDefinition> {
@@ -588,9 +681,9 @@ impl SeekParent for ErrorDefinition {
     }
 }
 
-// ExpressionStatement SeekParent allows us to finction an ExpressionStatement's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for ExpressionStatement {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// ExpressionStatement GetParent allows us to finction an ExpressionStatement's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for ExpressionStatement {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.expression_statements.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -599,7 +692,10 @@ impl SeekParent for ExpressionStatement {
         })
     }
 
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.expression_statements.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -611,7 +707,10 @@ impl SeekParent for ExpressionStatement {
         })
     }
 
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.expression_statements.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -623,7 +722,10 @@ impl SeekParent for ExpressionStatement {
         })
     }
 
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.expression_statements.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -636,9 +738,9 @@ impl SeekParent for ExpressionStatement {
     }
 }
 
-// FunctionCall SeekParent allows us to finction an FunctionCall's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for FunctionCall {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// FunctionCall GetParent allows us to finction an FunctionCall's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for FunctionCall {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.function_calls.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -647,7 +749,10 @@ impl SeekParent for FunctionCall {
         })
     }
 
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.function_calls.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -659,7 +764,10 @@ impl SeekParent for FunctionCall {
         })
     }
 
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.function_calls.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -671,7 +779,10 @@ impl SeekParent for FunctionCall {
         })
     }
 
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.function_calls.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -684,9 +795,9 @@ impl SeekParent for FunctionCall {
     }
 }
 
-// FunctionCallOptions SeekParent allows us to finction an FunctionCallOptions' parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for FunctionCallOptions {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// FunctionCallOptions GetParent allows us to finction an FunctionCallOptions' parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for FunctionCallOptions {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.function_call_options.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -695,7 +806,10 @@ impl SeekParent for FunctionCallOptions {
         })
     }
 
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.function_call_options.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -707,7 +821,10 @@ impl SeekParent for FunctionCallOptions {
         })
     }
 
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.function_call_options.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -719,7 +836,10 @@ impl SeekParent for FunctionCallOptions {
         })
     }
 
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.function_call_options.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -732,9 +852,9 @@ impl SeekParent for FunctionCallOptions {
     }
 }
 
-// FunctionDefinition SeekParent allows us to finction an FunctionDefinition's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for FunctionDefinition {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// FunctionDefinition GetParent allows us to finction an FunctionDefinition's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for FunctionDefinition {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.function_definitions.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -742,7 +862,10 @@ impl SeekParent for FunctionDefinition {
                 .find(|source_unit| source_unit.id == x.source_unit_id)
         })
     }
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.function_definitions.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -753,13 +876,13 @@ impl SeekParent for FunctionDefinition {
                 })
         })
     }
-    fn function_definition<'a>(
+    fn function_definition_of<'a>(
         &self,
         _loader: &'a ContextLoader,
     ) -> Option<&'a FunctionDefinition> {
         None
     }
-    fn modifier_definition<'a>(
+    fn modifier_definition_of<'a>(
         &self,
         _loader: &'a ContextLoader,
     ) -> Option<&'a ModifierDefinition> {
@@ -767,9 +890,9 @@ impl SeekParent for FunctionDefinition {
     }
 }
 
-// FunctionTypeName SeekParent allows us to finction an FunctionTypeName's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for FunctionTypeName {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// FunctionTypeName GetParent allows us to finction an FunctionTypeName's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for FunctionTypeName {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.function_type_names.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -777,7 +900,10 @@ impl SeekParent for FunctionTypeName {
                 .find(|source_unit| source_unit.id == x.source_unit_id)
         })
     }
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.function_type_names.get(self).and_then(move |x| {
             loader
                 .contract_definitions
@@ -788,7 +914,10 @@ impl SeekParent for FunctionTypeName {
         })
     }
 
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.function_type_names.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -800,7 +929,10 @@ impl SeekParent for FunctionTypeName {
         })
     }
 
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.function_type_names.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -813,9 +945,9 @@ impl SeekParent for FunctionTypeName {
     }
 }
 
-// ForStatement SeekParent allows us to finction an ForStatement's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for ForStatement {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// ForStatement GetParent allows us to finction an ForStatement's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for ForStatement {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.for_statements.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -823,7 +955,10 @@ impl SeekParent for ForStatement {
                 .find(|source_unit| source_unit.id == x.source_unit_id)
         })
     }
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.for_statements.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -834,7 +969,10 @@ impl SeekParent for ForStatement {
                 })
         })
     }
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.for_statements.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -845,7 +983,10 @@ impl SeekParent for ForStatement {
                 })
         })
     }
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.for_statements.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -858,9 +999,9 @@ impl SeekParent for ForStatement {
     }
 }
 
-// Identifier SeekParent allows us to finction an Identifier's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for Identifier {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// Identifier GetParent allows us to finction an Identifier's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for Identifier {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.identifiers.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -868,7 +1009,10 @@ impl SeekParent for Identifier {
                 .find(|source_unit| source_unit.id == x.source_unit_id)
         })
     }
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.identifiers.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -879,7 +1023,10 @@ impl SeekParent for Identifier {
                 })
         })
     }
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.identifiers.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -890,7 +1037,10 @@ impl SeekParent for Identifier {
                 })
         })
     }
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.identifiers.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -903,9 +1053,9 @@ impl SeekParent for Identifier {
     }
 }
 
-// IdentifierPath SeekParent allows us to finction an IdentifierPath's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for IdentifierPath {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// IdentifierPath GetParent allows us to finction an IdentifierPath's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for IdentifierPath {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.identifier_paths.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -914,7 +1064,10 @@ impl SeekParent for IdentifierPath {
         })
     }
 
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.identifier_paths.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -926,7 +1079,10 @@ impl SeekParent for IdentifierPath {
         })
     }
 
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.identifier_paths.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -938,7 +1094,10 @@ impl SeekParent for IdentifierPath {
         })
     }
 
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.identifier_paths.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -951,9 +1110,9 @@ impl SeekParent for IdentifierPath {
     }
 }
 
-// IfStatement SeekParent allows us to finction an IfStatement's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for IfStatement {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// IfStatement GetParent allows us to finction an IfStatement's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for IfStatement {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.if_statements.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -961,7 +1120,10 @@ impl SeekParent for IfStatement {
                 .find(|source_unit| source_unit.id == x.source_unit_id)
         })
     }
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.if_statements.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -972,7 +1134,10 @@ impl SeekParent for IfStatement {
                 })
         })
     }
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.if_statements.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -983,7 +1148,10 @@ impl SeekParent for IfStatement {
                 })
         })
     }
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.if_statements.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -996,9 +1164,9 @@ impl SeekParent for IfStatement {
     }
 }
 
-// ImportDirective SeekParent allows us to finction an ImportDirective's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for ImportDirective {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// ImportDirective GetParent allows us to finction an ImportDirective's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for ImportDirective {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.import_directives.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -1006,7 +1174,10 @@ impl SeekParent for ImportDirective {
                 .find(|source_unit| source_unit.id == x.source_unit_id)
         })
     }
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.import_directives.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -1017,7 +1188,10 @@ impl SeekParent for ImportDirective {
                 })
         })
     }
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.import_directives.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -1028,7 +1202,10 @@ impl SeekParent for ImportDirective {
                 })
         })
     }
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.import_directives.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -1041,9 +1218,9 @@ impl SeekParent for ImportDirective {
     }
 }
 
-// IndexAccess SeekParent allows us to finction an IndexAccess's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for IndexAccess {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// IndexAccess GetParent allows us to finction an IndexAccess's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for IndexAccess {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.index_accesses.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -1051,7 +1228,10 @@ impl SeekParent for IndexAccess {
                 .find(|source_unit| source_unit.id == x.source_unit_id)
         })
     }
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.index_accesses.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -1062,7 +1242,10 @@ impl SeekParent for IndexAccess {
                 })
         })
     }
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.index_accesses.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -1073,7 +1256,10 @@ impl SeekParent for IndexAccess {
                 })
         })
     }
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.index_accesses.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -1086,9 +1272,9 @@ impl SeekParent for IndexAccess {
     }
 }
 
-// IndexRangeAccess SeekParent allows us to finction an IndexRangeAccess's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for IndexRangeAccess {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// IndexRangeAccess GetParent allows us to finction an IndexRangeAccess's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for IndexRangeAccess {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.index_range_accesses.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -1096,7 +1282,10 @@ impl SeekParent for IndexRangeAccess {
                 .find(|source_unit| source_unit.id == x.source_unit_id)
         })
     }
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.index_range_accesses.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -1107,7 +1296,10 @@ impl SeekParent for IndexRangeAccess {
                 })
         })
     }
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.index_range_accesses.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -1118,7 +1310,10 @@ impl SeekParent for IndexRangeAccess {
                 })
         })
     }
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.index_range_accesses.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -1131,9 +1326,9 @@ impl SeekParent for IndexRangeAccess {
     }
 }
 
-// InheritanceSpecifier SeekParent allows us to finction an InheritanceSpecifier's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for InheritanceSpecifier {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// InheritanceSpecifier GetParent allows us to finction an InheritanceSpecifier's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for InheritanceSpecifier {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.inheritance_specifiers.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -1141,7 +1336,10 @@ impl SeekParent for InheritanceSpecifier {
                 .find(|source_unit| source_unit.id == x.source_unit_id)
         })
     }
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.inheritance_specifiers.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -1152,13 +1350,13 @@ impl SeekParent for InheritanceSpecifier {
                 })
         })
     }
-    fn function_definition<'a>(
+    fn function_definition_of<'a>(
         &self,
         _loader: &'a ContextLoader,
     ) -> Option<&'a FunctionDefinition> {
         None
     }
-    fn modifier_definition<'a>(
+    fn modifier_definition_of<'a>(
         &self,
         _loader: &'a ContextLoader,
     ) -> Option<&'a ModifierDefinition> {
@@ -1166,9 +1364,9 @@ impl SeekParent for InheritanceSpecifier {
     }
 }
 
-// InlineAssembly SeekParent allows us to finction an InlineAssembly's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for InlineAssembly {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// InlineAssembly GetParent allows us to finction an InlineAssembly's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for InlineAssembly {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.inline_assemblies.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -1177,7 +1375,10 @@ impl SeekParent for InlineAssembly {
         })
     }
 
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.inline_assemblies.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -1189,7 +1390,10 @@ impl SeekParent for InlineAssembly {
         })
     }
 
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.inline_assemblies.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -1201,7 +1405,10 @@ impl SeekParent for InlineAssembly {
         })
     }
 
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.inline_assemblies.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -1214,9 +1421,9 @@ impl SeekParent for InlineAssembly {
     }
 }
 
-// Literal SeekParent allows us to finction an Literal's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for Literal {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// Literal GetParent allows us to finction an Literal's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for Literal {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.literals.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -1224,7 +1431,10 @@ impl SeekParent for Literal {
                 .find(|source_unit| source_unit.id == x.source_unit_id)
         })
     }
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.literals.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -1235,7 +1445,10 @@ impl SeekParent for Literal {
                 })
         })
     }
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.literals.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -1246,7 +1459,10 @@ impl SeekParent for Literal {
                 })
         })
     }
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.literals.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -1259,9 +1475,9 @@ impl SeekParent for Literal {
     }
 }
 
-// MemberAccess SeekParent allows us to finction an MemberAccess's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for MemberAccess {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// MemberAccess GetParent allows us to finction an MemberAccess's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for MemberAccess {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.member_accesses.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -1269,7 +1485,10 @@ impl SeekParent for MemberAccess {
                 .find(|source_unit| source_unit.id == x.source_unit_id)
         })
     }
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.member_accesses.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -1280,7 +1499,10 @@ impl SeekParent for MemberAccess {
                 })
         })
     }
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.member_accesses.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -1291,7 +1513,10 @@ impl SeekParent for MemberAccess {
                 })
         })
     }
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.member_accesses.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -1304,9 +1529,9 @@ impl SeekParent for MemberAccess {
     }
 }
 
-// NewExpression SeekParent allows us to finction an NewExpression's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for NewExpression {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// NewExpression GetParent allows us to finction an NewExpression's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for NewExpression {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.new_expressions.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -1314,7 +1539,10 @@ impl SeekParent for NewExpression {
                 .find(|source_unit| source_unit.id == x.source_unit_id)
         })
     }
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.new_expressions.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -1325,7 +1553,10 @@ impl SeekParent for NewExpression {
                 })
         })
     }
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.new_expressions.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -1336,7 +1567,10 @@ impl SeekParent for NewExpression {
                 })
         })
     }
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.new_expressions.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -1349,9 +1583,9 @@ impl SeekParent for NewExpression {
     }
 }
 
-// Mapping SeekParent allows us to finction an Mapping's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for Mapping {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// Mapping GetParent allows us to finction an Mapping's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for Mapping {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.mappings.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -1359,7 +1593,10 @@ impl SeekParent for Mapping {
                 .find(|source_unit| source_unit.id == x.source_unit_id)
         })
     }
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.mappings.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -1370,7 +1607,10 @@ impl SeekParent for Mapping {
                 })
         })
     }
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.mappings.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -1381,7 +1621,10 @@ impl SeekParent for Mapping {
                 })
         })
     }
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.mappings.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -1394,9 +1637,9 @@ impl SeekParent for Mapping {
     }
 }
 
-// ModifierDefinition SeekParent allows us to finction an ModifierDefinition's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for ModifierDefinition {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// ModifierDefinition GetParent allows us to finction an ModifierDefinition's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for ModifierDefinition {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.modifier_definitions.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -1404,7 +1647,10 @@ impl SeekParent for ModifierDefinition {
                 .find(|source_unit| source_unit.id == x.source_unit_id)
         })
     }
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.modifier_definitions.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -1415,7 +1661,10 @@ impl SeekParent for ModifierDefinition {
                 })
         })
     }
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.modifier_definitions.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -1426,7 +1675,7 @@ impl SeekParent for ModifierDefinition {
                 })
         })
     }
-    fn modifier_definition<'a>(
+    fn modifier_definition_of<'a>(
         &self,
         _loader: &'a ContextLoader,
     ) -> Option<&'a ModifierDefinition> {
@@ -1434,9 +1683,9 @@ impl SeekParent for ModifierDefinition {
     }
 }
 
-// ModifierInvocation SeekParent allows us to finction an ModifierInvocation's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for ModifierInvocation {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// ModifierInvocation GetParent allows us to finction an ModifierInvocation's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for ModifierInvocation {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.modifier_invocations.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -1444,7 +1693,10 @@ impl SeekParent for ModifierInvocation {
                 .find(|source_unit| source_unit.id == x.source_unit_id)
         })
     }
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.modifier_invocations.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -1455,7 +1707,10 @@ impl SeekParent for ModifierInvocation {
                 })
         })
     }
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.modifier_invocations.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -1466,7 +1721,7 @@ impl SeekParent for ModifierInvocation {
                 })
         })
     }
-    fn modifier_definition<'a>(
+    fn modifier_definition_of<'a>(
         &self,
         _loader: &'a ContextLoader,
     ) -> Option<&'a ModifierDefinition> {
@@ -1474,9 +1729,9 @@ impl SeekParent for ModifierInvocation {
     }
 }
 
-// OverrideSpecifier SeekParent allows us to finction an OverrideSpecifier's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for OverrideSpecifier {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// OverrideSpecifier GetParent allows us to finction an OverrideSpecifier's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for OverrideSpecifier {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.override_specifiers.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -1484,7 +1739,10 @@ impl SeekParent for OverrideSpecifier {
                 .find(|source_unit| source_unit.id == x.source_unit_id)
         })
     }
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.override_specifiers.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -1495,7 +1753,10 @@ impl SeekParent for OverrideSpecifier {
                 })
         })
     }
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.override_specifiers.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -1506,7 +1767,10 @@ impl SeekParent for OverrideSpecifier {
                 })
         })
     }
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.override_specifiers.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -1519,9 +1783,9 @@ impl SeekParent for OverrideSpecifier {
     }
 }
 
-// ParameterList SeekParent allows us to finction an ParameterList's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for ParameterList {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// ParameterList GetParent allows us to finction an ParameterList's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for ParameterList {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.parameter_lists.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -1529,7 +1793,10 @@ impl SeekParent for ParameterList {
                 .find(|source_unit| source_unit.id == x.source_unit_id)
         })
     }
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.parameter_lists.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -1540,7 +1807,10 @@ impl SeekParent for ParameterList {
                 })
         })
     }
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.parameter_lists.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -1551,7 +1821,10 @@ impl SeekParent for ParameterList {
                 })
         })
     }
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.parameter_lists.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -1564,9 +1837,9 @@ impl SeekParent for ParameterList {
     }
 }
 
-// PragmaDirective SeekParent allows us to finction an PragmaDirective's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for PragmaDirective {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// PragmaDirective GetParent allows us to finction an PragmaDirective's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for PragmaDirective {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.pragma_directives.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -1574,19 +1847,19 @@ impl SeekParent for PragmaDirective {
                 .find(|source_unit| source_unit.id == x.source_unit_id)
         })
     }
-    fn contract_definition<'a>(
+    fn contract_definition_of<'a>(
         &self,
         _loader: &'a ContextLoader,
     ) -> Option<&'a ContractDefinition> {
         None
     }
-    fn function_definition<'a>(
+    fn function_definition_of<'a>(
         &self,
         _loader: &'a ContextLoader,
     ) -> Option<&'a FunctionDefinition> {
         None
     }
-    fn modifier_definition<'a>(
+    fn modifier_definition_of<'a>(
         &self,
         _loader: &'a ContextLoader,
     ) -> Option<&'a ModifierDefinition> {
@@ -1594,9 +1867,9 @@ impl SeekParent for PragmaDirective {
     }
 }
 
-// Return SeekParent allows us to finction an Return's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for Return {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// Return GetParent allows us to finction an Return's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for Return {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.returns.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -1604,7 +1877,10 @@ impl SeekParent for Return {
                 .find(|source_unit| source_unit.id == x.source_unit_id)
         })
     }
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.returns.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -1615,7 +1891,10 @@ impl SeekParent for Return {
                 })
         })
     }
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.returns.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -1626,7 +1905,10 @@ impl SeekParent for Return {
                 })
         })
     }
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.returns.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -1639,9 +1921,9 @@ impl SeekParent for Return {
     }
 }
 
-// RevertStatement SeekParent allows us to finction an RevertStatement's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for RevertStatement {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// RevertStatement GetParent allows us to finction an RevertStatement's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for RevertStatement {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.revert_statements.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -1649,7 +1931,10 @@ impl SeekParent for RevertStatement {
                 .find(|source_unit| source_unit.id == x.source_unit_id)
         })
     }
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.revert_statements.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -1660,7 +1945,10 @@ impl SeekParent for RevertStatement {
                 })
         })
     }
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.revert_statements.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -1671,7 +1959,10 @@ impl SeekParent for RevertStatement {
                 })
         })
     }
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.revert_statements.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -1684,9 +1975,9 @@ impl SeekParent for RevertStatement {
     }
 }
 
-// StructDefinition SeekParent allows us to finction an StructDefinition's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for StructDefinition {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// StructDefinition GetParent allows us to finction an StructDefinition's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for StructDefinition {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.struct_definitions.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -1694,7 +1985,10 @@ impl SeekParent for StructDefinition {
                 .find(|source_unit| source_unit.id == x.source_unit_id)
         })
     }
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.struct_definitions.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -1705,7 +1999,10 @@ impl SeekParent for StructDefinition {
                 })
         })
     }
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.struct_definitions.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -1716,7 +2013,10 @@ impl SeekParent for StructDefinition {
                 })
         })
     }
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.struct_definitions.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -1729,9 +2029,9 @@ impl SeekParent for StructDefinition {
     }
 }
 
-// StructuredDocumentation SeekParent allows us to finction an StructuredDocumentation's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for StructuredDocumentation {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// StructuredDocumentation GetParent allows us to finction an StructuredDocumentation's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for StructuredDocumentation {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader
             .structured_documentations
             .get(self)
@@ -1742,7 +2042,10 @@ impl SeekParent for StructuredDocumentation {
                     .find(|source_unit| source_unit.id == x.source_unit_id)
             })
     }
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader
             .structured_documentations
             .get(self)
@@ -1756,7 +2059,10 @@ impl SeekParent for StructuredDocumentation {
                     })
             })
     }
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader
             .structured_documentations
             .get(self)
@@ -1770,7 +2076,10 @@ impl SeekParent for StructuredDocumentation {
                     })
             })
     }
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader
             .structured_documentations
             .get(self)
@@ -1786,9 +2095,9 @@ impl SeekParent for StructuredDocumentation {
     }
 }
 
-// TryStatement SeekParent allows us to finction an TryStatement's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for TryStatement {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// TryStatement GetParent allows us to finction an TryStatement's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for TryStatement {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.try_statements.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -1797,7 +2106,10 @@ impl SeekParent for TryStatement {
         })
     }
 
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.try_statements.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -1809,7 +2121,10 @@ impl SeekParent for TryStatement {
         })
     }
 
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.try_statements.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -1821,7 +2136,10 @@ impl SeekParent for TryStatement {
         })
     }
 
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.try_statements.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -1834,9 +2152,9 @@ impl SeekParent for TryStatement {
     }
 }
 
-// TryCatchClause SeekParent allows us to finction an TryCatchClause's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for TryCatchClause {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// TryCatchClause GetParent allows us to finction an TryCatchClause's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for TryCatchClause {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.try_catch_clauses.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -1845,7 +2163,10 @@ impl SeekParent for TryCatchClause {
         })
     }
 
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.try_catch_clauses.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -1857,7 +2178,10 @@ impl SeekParent for TryCatchClause {
         })
     }
 
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.try_catch_clauses.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -1869,7 +2193,10 @@ impl SeekParent for TryCatchClause {
         })
     }
 
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.try_catch_clauses.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -1882,9 +2209,9 @@ impl SeekParent for TryCatchClause {
     }
 }
 
-// TupleExpression SeekParent allows us to finction an TupleExpression's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for TupleExpression {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// TupleExpression GetParent allows us to finction an TupleExpression's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for TupleExpression {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.tuple_expressions.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -1893,7 +2220,10 @@ impl SeekParent for TupleExpression {
         })
     }
 
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.tuple_expressions.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -1905,7 +2235,10 @@ impl SeekParent for TupleExpression {
         })
     }
 
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.tuple_expressions.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -1917,7 +2250,10 @@ impl SeekParent for TupleExpression {
         })
     }
 
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.tuple_expressions.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -1930,9 +2266,9 @@ impl SeekParent for TupleExpression {
     }
 }
 
-// UnaryOperation SeekParent allows us to finction an UnaryOperation's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for UnaryOperation {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// UnaryOperation GetParent allows us to finction an UnaryOperation's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for UnaryOperation {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.unary_operations.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -1941,7 +2277,10 @@ impl SeekParent for UnaryOperation {
         })
     }
 
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.unary_operations.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -1953,7 +2292,10 @@ impl SeekParent for UnaryOperation {
         })
     }
 
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.unary_operations.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -1965,7 +2307,10 @@ impl SeekParent for UnaryOperation {
         })
     }
 
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.unary_operations.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -1978,9 +2323,9 @@ impl SeekParent for UnaryOperation {
     }
 }
 
-// UserDefinedTypeName SeekParent allows us to finction an UserDefinedTypeName's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for UserDefinedTypeName {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// UserDefinedTypeName GetParent allows us to finction an UserDefinedTypeName's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for UserDefinedTypeName {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.user_defined_type_names.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -1989,7 +2334,10 @@ impl SeekParent for UserDefinedTypeName {
         })
     }
 
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.user_defined_type_names.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -2001,7 +2349,10 @@ impl SeekParent for UserDefinedTypeName {
         })
     }
 
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.user_defined_type_names.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -2013,7 +2364,10 @@ impl SeekParent for UserDefinedTypeName {
         })
     }
 
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.user_defined_type_names.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -2026,9 +2380,9 @@ impl SeekParent for UserDefinedTypeName {
     }
 }
 
-// UsingStatement SeekParent allows us to finction an UsingStatement's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for UserDefinedValueTypeDefinition {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// UsingStatement GetParent allows us to finction an UsingStatement's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for UserDefinedValueTypeDefinition {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader
             .user_defined_value_type_definitions
             .get(self)
@@ -2040,7 +2394,10 @@ impl SeekParent for UserDefinedValueTypeDefinition {
             })
     }
 
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader
             .user_defined_value_type_definitions
             .get(self)
@@ -2055,7 +2412,10 @@ impl SeekParent for UserDefinedValueTypeDefinition {
             })
     }
 
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader
             .user_defined_value_type_definitions
             .get(self)
@@ -2070,7 +2430,10 @@ impl SeekParent for UserDefinedValueTypeDefinition {
             })
     }
 
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader
             .user_defined_value_type_definitions
             .get(self)
@@ -2086,9 +2449,9 @@ impl SeekParent for UserDefinedValueTypeDefinition {
     }
 }
 
-// UsingForDirective SeekParent allows us to finction an UsingForDirective's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for UsingForDirective {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// UsingForDirective GetParent allows us to finction an UsingForDirective's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for UsingForDirective {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.using_for_directives.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -2097,7 +2460,10 @@ impl SeekParent for UsingForDirective {
         })
     }
 
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.using_for_directives.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -2109,7 +2475,10 @@ impl SeekParent for UsingForDirective {
         })
     }
 
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.using_for_directives.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -2121,7 +2490,10 @@ impl SeekParent for UsingForDirective {
         })
     }
 
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.using_for_directives.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -2134,9 +2506,9 @@ impl SeekParent for UsingForDirective {
     }
 }
 
-// VariableDeclaration SeekParent allows us to finction an VariableDeclaration's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for VariableDeclaration {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// VariableDeclaration GetParent allows us to finction an VariableDeclaration's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for VariableDeclaration {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.variable_declarations.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -2145,7 +2517,10 @@ impl SeekParent for VariableDeclaration {
         })
     }
 
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.variable_declarations.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -2157,7 +2532,10 @@ impl SeekParent for VariableDeclaration {
         })
     }
 
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.variable_declarations.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -2169,7 +2547,10 @@ impl SeekParent for VariableDeclaration {
         })
     }
 
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.variable_declarations.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader
@@ -2182,9 +2563,9 @@ impl SeekParent for VariableDeclaration {
     }
 }
 
-// VariableDeclarationStatement SeekParent allows us to finction an VariableDeclarationStatement's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for VariableDeclarationStatement {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// VariableDeclarationStatement GetParent allows us to finction an VariableDeclarationStatement's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for VariableDeclarationStatement {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader
             .variable_declaration_statements
             .get(self)
@@ -2196,7 +2577,10 @@ impl SeekParent for VariableDeclarationStatement {
             })
     }
 
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader
             .variable_declaration_statements
             .get(self)
@@ -2211,7 +2595,10 @@ impl SeekParent for VariableDeclarationStatement {
             })
     }
 
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader
             .variable_declaration_statements
             .get(self)
@@ -2226,7 +2613,10 @@ impl SeekParent for VariableDeclarationStatement {
             })
     }
 
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader
             .variable_declaration_statements
             .get(self)
@@ -2242,9 +2632,9 @@ impl SeekParent for VariableDeclarationStatement {
     }
 }
 
-// WhileStatement SeekParent allows us to finction an WhileStatement's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
-impl SeekParent for WhileStatement {
-    fn source_unit<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
+// WhileStatement GetParent allows us to finction an WhileStatement's parent SourceUnit, ContractDefinition, FunctionDefinition or ModifierDefinition
+impl GetParent for WhileStatement {
+    fn source_unit_of<'a>(&self, loader: &'a ContextLoader) -> Option<&'a SourceUnit> {
         loader.while_statements.get(self).and_then(move |x| {
             loader
                 .source_units
@@ -2253,7 +2643,10 @@ impl SeekParent for WhileStatement {
         })
     }
 
-    fn contract_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ContractDefinition> {
+    fn contract_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ContractDefinition> {
         loader.while_statements.get(self).and_then(move |x| {
             x.contract_definition_id?;
             loader
@@ -2265,7 +2658,10 @@ impl SeekParent for WhileStatement {
         })
     }
 
-    fn function_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a FunctionDefinition> {
+    fn function_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a FunctionDefinition> {
         loader.while_statements.get(self).and_then(move |x| {
             x.function_definition_id?;
             loader
@@ -2277,7 +2673,10 @@ impl SeekParent for WhileStatement {
         })
     }
 
-    fn modifier_definition<'a>(&self, loader: &'a ContextLoader) -> Option<&'a ModifierDefinition> {
+    fn modifier_definition_of<'a>(
+        &self,
+        loader: &'a ContextLoader,
+    ) -> Option<&'a ModifierDefinition> {
         loader.while_statements.get(self).and_then(move |x| {
             x.modifier_definition_id?;
             loader

--- a/aderyn_core/src/context/loader.rs
+++ b/aderyn_core/src/context/loader.rs
@@ -203,205 +203,155 @@ impl ContextLoader {
         let source_unit_id = match node {
             ASTNode::ArrayTypeName(node) => self
                 .array_type_names
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::Assignment(node) => self
                 .assignments
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::BinaryOperation(node) => self
                 .binary_operations
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::Block(node) => self
                 .blocks
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::Conditional(node) => self
                 .conditionals
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::ContractDefinition(node) => self
                 .contract_definitions
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::ElementaryTypeName(node) => self
                 .elementary_type_names
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::ElementaryTypeNameExpression(node) => self
                 .elementary_type_name_expressions
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::EmitStatement(node) => self
                 .emit_statements
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::EnumDefinition(node) => self
                 .enum_definitions
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::EnumValue(node) => self
                 .enum_values
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::EventDefinition(node) => self
                 .event_definitions
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::ErrorDefinition(node) => self
                 .error_definitions
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::ExpressionStatement(node) => self
                 .expression_statements
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::FunctionCall(node) => self
                 .function_calls
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::FunctionCallOptions(node) => self
                 .function_call_options
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::FunctionDefinition(node) => self
                 .function_definitions
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::FunctionTypeName(node) => self
                 .function_type_names
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::ForStatement(node) => self
                 .for_statements
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::Identifier(node) => self
                 .identifiers
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::IdentifierPath(node) => self
                 .identifier_paths
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::IfStatement(node) => self
                 .if_statements
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::ImportDirective(node) => self
                 .import_directives
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::IndexAccess(node) => self
                 .index_accesses
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::IndexRangeAccess(node) => self
                 .index_range_accesses
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::InheritanceSpecifier(node) => self
                 .inheritance_specifiers
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::InlineAssembly(node) => self
                 .inline_assemblies
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::Literal(node) => self
                 .literals
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::MemberAccess(node) => self
                 .member_accesses
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::NewExpression(node) => self
                 .new_expressions
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::Mapping(node) => self
                 .mappings
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::ModifierDefinition(node) => self
                 .modifier_definitions
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::ModifierInvocation(node) => self
                 .modifier_invocations
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::OverrideSpecifier(node) => self
                 .override_specifiers
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::ParameterList(node) => self
                 .parameter_lists
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::PragmaDirective(node) => self
                 .pragma_directives
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::Return(node) => self
                 .returns
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::RevertStatement(node) => self
                 .revert_statements
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::SourceUnit(node) => Some(node.id),
             ASTNode::StructDefinition(node) => self
                 .struct_definitions
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::StructuredDocumentation(node) => self
                 .structured_documentations
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::TryStatement(node) => self
                 .try_statements
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::TryCatchClause(node) => self
                 .try_catch_clauses
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::TupleExpression(node) => self
                 .tuple_expressions
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::UnaryOperation(node) => self
                 .unary_operations
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::UserDefinedTypeName(node) => self
                 .user_defined_type_names
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::UserDefinedValueTypeDefinition(node) => self
                 .user_defined_value_type_definitions
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::UsingForDirective(node) => self
                 .using_for_directives
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::VariableDeclaration(node) => self
                 .variable_declarations
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::VariableDeclarationStatement(node) => self
                 .variable_declaration_statements
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
             ASTNode::WhileStatement(node) => self
                 .while_statements
-                .get(node)
-                .and_then(|context| Some(context.source_unit_id)),
+                .get(node).map(|context| context.source_unit_id),
         };
 
         // iterate through self.source_units until the source unit with the id matching `source_unit_id` is found, then return its `absolute_path`

--- a/aderyn_core/src/context/loader.rs
+++ b/aderyn_core/src/context/loader.rs
@@ -203,155 +203,199 @@ impl ContextLoader {
         let source_unit_id = match node {
             ASTNode::ArrayTypeName(node) => self
                 .array_type_names
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::Assignment(node) => self
                 .assignments
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::BinaryOperation(node) => self
                 .binary_operations
-                .get(node).map(|context| context.source_unit_id),
-            ASTNode::Block(node) => self
-                .blocks
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
+            ASTNode::Block(node) => self.blocks.get(node).map(|context| context.source_unit_id),
             ASTNode::Conditional(node) => self
                 .conditionals
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::ContractDefinition(node) => self
                 .contract_definitions
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::ElementaryTypeName(node) => self
                 .elementary_type_names
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::ElementaryTypeNameExpression(node) => self
                 .elementary_type_name_expressions
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::EmitStatement(node) => self
                 .emit_statements
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::EnumDefinition(node) => self
                 .enum_definitions
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::EnumValue(node) => self
                 .enum_values
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::EventDefinition(node) => self
                 .event_definitions
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::ErrorDefinition(node) => self
                 .error_definitions
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::ExpressionStatement(node) => self
                 .expression_statements
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::FunctionCall(node) => self
                 .function_calls
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::FunctionCallOptions(node) => self
                 .function_call_options
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::FunctionDefinition(node) => self
                 .function_definitions
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::FunctionTypeName(node) => self
                 .function_type_names
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::ForStatement(node) => self
                 .for_statements
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::Identifier(node) => self
                 .identifiers
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::IdentifierPath(node) => self
                 .identifier_paths
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::IfStatement(node) => self
                 .if_statements
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::ImportDirective(node) => self
                 .import_directives
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::IndexAccess(node) => self
                 .index_accesses
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::IndexRangeAccess(node) => self
                 .index_range_accesses
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::InheritanceSpecifier(node) => self
                 .inheritance_specifiers
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::InlineAssembly(node) => self
                 .inline_assemblies
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::Literal(node) => self
                 .literals
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::MemberAccess(node) => self
                 .member_accesses
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::NewExpression(node) => self
                 .new_expressions
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::Mapping(node) => self
                 .mappings
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::ModifierDefinition(node) => self
                 .modifier_definitions
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::ModifierInvocation(node) => self
                 .modifier_invocations
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::OverrideSpecifier(node) => self
                 .override_specifiers
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::ParameterList(node) => self
                 .parameter_lists
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::PragmaDirective(node) => self
                 .pragma_directives
-                .get(node).map(|context| context.source_unit_id),
-            ASTNode::Return(node) => self
-                .returns
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
+            ASTNode::Return(node) => self.returns.get(node).map(|context| context.source_unit_id),
             ASTNode::RevertStatement(node) => self
                 .revert_statements
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::SourceUnit(node) => Some(node.id),
             ASTNode::StructDefinition(node) => self
                 .struct_definitions
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::StructuredDocumentation(node) => self
                 .structured_documentations
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::TryStatement(node) => self
                 .try_statements
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::TryCatchClause(node) => self
                 .try_catch_clauses
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::TupleExpression(node) => self
                 .tuple_expressions
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::UnaryOperation(node) => self
                 .unary_operations
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::UserDefinedTypeName(node) => self
                 .user_defined_type_names
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::UserDefinedValueTypeDefinition(node) => self
                 .user_defined_value_type_definitions
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::UsingForDirective(node) => self
                 .using_for_directives
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::VariableDeclaration(node) => self
                 .variable_declarations
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::VariableDeclarationStatement(node) => self
                 .variable_declaration_statements
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
             ASTNode::WhileStatement(node) => self
                 .while_statements
-                .get(node).map(|context| context.source_unit_id),
+                .get(node)
+                .map(|context| context.source_unit_id),
         };
 
         // iterate through self.source_units until the source unit with the id matching `source_unit_id` is found, then return its `absolute_path`

--- a/aderyn_core/src/context/loader.rs
+++ b/aderyn_core/src/context/loader.rs
@@ -116,66 +116,78 @@ impl ASTNode {
     }
 }
 
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct NodeContext {
+    pub source_unit_id: i64,
+    pub contract_definition_id: Option<i64>,
+    pub function_definition_id: Option<i64>,
+    pub modifier_definition_id: Option<i64>,
+}
+
 #[derive(Default, Debug)]
 pub struct ContextLoader {
+    last_source_unit_id: i64,
+    last_contract_definition_id: Option<i64>,
+    last_function_definition_id: Option<i64>,
+    last_modifier_definition_id: Option<i64>,
+
     // relative source filepaths
     pub src_filepaths: Vec<String>,
     pub sloc_stats: HashMap<String, usize>,
     pub nodes: HashMap<i64, ASTNode>,
-    last_source_unit_id: i64,
 
     // Hashmaps of all nodes => source_unit_id
-    pub array_type_names: HashMap<ArrayTypeName, i64>,
-    pub assignments: HashMap<Assignment, i64>,
-    pub binary_operations: HashMap<BinaryOperation, i64>,
-    pub blocks: HashMap<Block, i64>,
-    pub conditionals: HashMap<Conditional, i64>,
-    pub contract_definitions: HashMap<ContractDefinition, i64>,
-    pub elementary_type_names: HashMap<ElementaryTypeName, i64>,
-    pub elementary_type_name_expressions: HashMap<ElementaryTypeNameExpression, i64>,
-    pub emit_statements: HashMap<EmitStatement, i64>,
-    pub enum_definitions: HashMap<EnumDefinition, i64>,
-    pub enum_values: HashMap<EnumValue, i64>,
-    pub event_definitions: HashMap<EventDefinition, i64>,
-    pub error_definitions: HashMap<ErrorDefinition, i64>,
-    pub expression_statements: HashMap<ExpressionStatement, i64>,
-    pub function_calls: HashMap<FunctionCall, i64>,
-    pub function_call_options: HashMap<FunctionCallOptions, i64>,
-    pub function_definitions: HashMap<FunctionDefinition, i64>,
-    pub function_type_names: HashMap<FunctionTypeName, i64>,
-    pub for_statements: HashMap<ForStatement, i64>,
-    pub identifiers: HashMap<Identifier, i64>,
-    pub identifier_paths: HashMap<IdentifierPath, i64>,
-    pub if_statements: HashMap<IfStatement, i64>,
-    pub import_directives: HashMap<ImportDirective, i64>,
-    pub index_accesses: HashMap<IndexAccess, i64>,
-    pub index_range_accesses: HashMap<IndexRangeAccess, i64>,
-    pub inheritance_specifiers: HashMap<InheritanceSpecifier, i64>,
-    pub inline_assemblies: HashMap<InlineAssembly, i64>,
-    pub literals: HashMap<Literal, i64>,
-    pub member_accesses: HashMap<MemberAccess, i64>,
-    pub new_expressions: HashMap<NewExpression, i64>,
-    pub mappings: HashMap<Mapping, i64>,
-    pub modifier_definitions: HashMap<ModifierDefinition, i64>,
-    pub modifier_invocations: HashMap<ModifierInvocation, i64>,
-    pub override_specifiers: HashMap<OverrideSpecifier, i64>,
-    pub parameter_lists: HashMap<ParameterList, i64>,
-    pub pragma_directives: HashMap<PragmaDirective, i64>,
-    pub returns: HashMap<Return, i64>,
-    pub revert_statements: HashMap<RevertStatement, i64>,
+    pub array_type_names: HashMap<ArrayTypeName, NodeContext>,
+    pub assignments: HashMap<Assignment, NodeContext>,
+    pub binary_operations: HashMap<BinaryOperation, NodeContext>,
+    pub blocks: HashMap<Block, NodeContext>,
+    pub conditionals: HashMap<Conditional, NodeContext>,
+    pub contract_definitions: HashMap<ContractDefinition, NodeContext>,
+    pub elementary_type_names: HashMap<ElementaryTypeName, NodeContext>,
+    pub elementary_type_name_expressions: HashMap<ElementaryTypeNameExpression, NodeContext>,
+    pub emit_statements: HashMap<EmitStatement, NodeContext>,
+    pub enum_definitions: HashMap<EnumDefinition, NodeContext>,
+    pub enum_values: HashMap<EnumValue, NodeContext>,
+    pub event_definitions: HashMap<EventDefinition, NodeContext>,
+    pub error_definitions: HashMap<ErrorDefinition, NodeContext>,
+    pub expression_statements: HashMap<ExpressionStatement, NodeContext>,
+    pub function_calls: HashMap<FunctionCall, NodeContext>,
+    pub function_call_options: HashMap<FunctionCallOptions, NodeContext>,
+    pub function_definitions: HashMap<FunctionDefinition, NodeContext>,
+    pub function_type_names: HashMap<FunctionTypeName, NodeContext>,
+    pub for_statements: HashMap<ForStatement, NodeContext>,
+    pub identifiers: HashMap<Identifier, NodeContext>,
+    pub identifier_paths: HashMap<IdentifierPath, NodeContext>,
+    pub if_statements: HashMap<IfStatement, NodeContext>,
+    pub import_directives: HashMap<ImportDirective, NodeContext>,
+    pub index_accesses: HashMap<IndexAccess, NodeContext>,
+    pub index_range_accesses: HashMap<IndexRangeAccess, NodeContext>,
+    pub inheritance_specifiers: HashMap<InheritanceSpecifier, NodeContext>,
+    pub inline_assemblies: HashMap<InlineAssembly, NodeContext>,
+    pub literals: HashMap<Literal, NodeContext>,
+    pub member_accesses: HashMap<MemberAccess, NodeContext>,
+    pub new_expressions: HashMap<NewExpression, NodeContext>,
+    pub mappings: HashMap<Mapping, NodeContext>,
+    pub modifier_definitions: HashMap<ModifierDefinition, NodeContext>,
+    pub modifier_invocations: HashMap<ModifierInvocation, NodeContext>,
+    pub override_specifiers: HashMap<OverrideSpecifier, NodeContext>,
+    pub parameter_lists: HashMap<ParameterList, NodeContext>,
+    pub pragma_directives: HashMap<PragmaDirective, NodeContext>,
+    pub returns: HashMap<Return, NodeContext>,
+    pub revert_statements: HashMap<RevertStatement, NodeContext>,
     pub source_units: Vec<SourceUnit>,
-    pub struct_definitions: HashMap<StructDefinition, i64>,
-    pub structured_documentations: HashMap<StructuredDocumentation, i64>,
-    pub try_statements: HashMap<TryStatement, i64>,
-    pub try_catch_clauses: HashMap<TryCatchClause, i64>,
-    pub tuple_expressions: HashMap<TupleExpression, i64>,
-    pub unary_operations: HashMap<UnaryOperation, i64>,
-    pub user_defined_type_names: HashMap<UserDefinedTypeName, i64>,
-    pub user_defined_value_type_definitions: HashMap<UserDefinedValueTypeDefinition, i64>,
-    pub using_for_directives: HashMap<UsingForDirective, i64>,
-    pub variable_declarations: HashMap<VariableDeclaration, i64>,
-    pub variable_declaration_statements: HashMap<VariableDeclarationStatement, i64>,
-    pub while_statements: HashMap<WhileStatement, i64>,
+    pub struct_definitions: HashMap<StructDefinition, NodeContext>,
+    pub structured_documentations: HashMap<StructuredDocumentation, NodeContext>,
+    pub try_statements: HashMap<TryStatement, NodeContext>,
+    pub try_catch_clauses: HashMap<TryCatchClause, NodeContext>,
+    pub tuple_expressions: HashMap<TupleExpression, NodeContext>,
+    pub unary_operations: HashMap<UnaryOperation, NodeContext>,
+    pub user_defined_type_names: HashMap<UserDefinedTypeName, NodeContext>,
+    pub user_defined_value_type_definitions: HashMap<UserDefinedValueTypeDefinition, NodeContext>,
+    pub using_for_directives: HashMap<UsingForDirective, NodeContext>,
+    pub variable_declarations: HashMap<VariableDeclaration, NodeContext>,
+    pub variable_declaration_statements: HashMap<VariableDeclarationStatement, NodeContext>,
+    pub while_statements: HashMap<WhileStatement, NodeContext>,
 }
 
 impl ContextLoader {
@@ -189,68 +201,212 @@ impl ContextLoader {
 
     pub fn get_source_unit_from_child_node(&self, node: &ASTNode) -> Option<&SourceUnit> {
         let source_unit_id = match node {
-            ASTNode::ArrayTypeName(node) => self.array_type_names.get(node),
-            ASTNode::Assignment(node) => self.assignments.get(node),
-            ASTNode::BinaryOperation(node) => self.binary_operations.get(node),
-            ASTNode::Block(node) => self.blocks.get(node),
-            ASTNode::Conditional(node) => self.conditionals.get(node),
-            ASTNode::ContractDefinition(node) => self.contract_definitions.get(node),
-            ASTNode::ElementaryTypeName(node) => self.elementary_type_names.get(node),
-            ASTNode::ElementaryTypeNameExpression(node) => {
-                self.elementary_type_name_expressions.get(node)
-            }
-            ASTNode::EmitStatement(node) => self.emit_statements.get(node),
-            ASTNode::EnumDefinition(node) => self.enum_definitions.get(node),
-            ASTNode::EnumValue(node) => self.enum_values.get(node),
-            ASTNode::EventDefinition(node) => self.event_definitions.get(node),
-            ASTNode::ErrorDefinition(node) => self.error_definitions.get(node),
-            ASTNode::ExpressionStatement(node) => self.expression_statements.get(node),
-            ASTNode::FunctionCall(node) => self.function_calls.get(node),
-            ASTNode::FunctionCallOptions(node) => self.function_call_options.get(node),
-            ASTNode::FunctionDefinition(node) => self.function_definitions.get(node),
-            ASTNode::FunctionTypeName(node) => self.function_type_names.get(node),
-            ASTNode::ForStatement(node) => self.for_statements.get(node),
-            ASTNode::Identifier(node) => self.identifiers.get(node),
-            ASTNode::IdentifierPath(node) => self.identifier_paths.get(node),
-            ASTNode::IfStatement(node) => self.if_statements.get(node),
-            ASTNode::ImportDirective(node) => self.import_directives.get(node),
-            ASTNode::IndexAccess(node) => self.index_accesses.get(node),
-            ASTNode::IndexRangeAccess(node) => self.index_range_accesses.get(node),
-            ASTNode::InheritanceSpecifier(node) => self.inheritance_specifiers.get(node),
-            ASTNode::InlineAssembly(node) => self.inline_assemblies.get(node),
-            ASTNode::Literal(node) => self.literals.get(node),
-            ASTNode::MemberAccess(node) => self.member_accesses.get(node),
-            ASTNode::NewExpression(node) => self.new_expressions.get(node),
-            ASTNode::Mapping(node) => self.mappings.get(node),
-            ASTNode::ModifierDefinition(node) => self.modifier_definitions.get(node),
-            ASTNode::ModifierInvocation(node) => self.modifier_invocations.get(node),
-            ASTNode::OverrideSpecifier(node) => self.override_specifiers.get(node),
-            ASTNode::ParameterList(node) => self.parameter_lists.get(node),
-            ASTNode::PragmaDirective(node) => self.pragma_directives.get(node),
-            ASTNode::Return(node) => self.returns.get(node),
-            ASTNode::RevertStatement(node) => self.revert_statements.get(node),
-            ASTNode::SourceUnit(node) => Some(&node.id),
-            ASTNode::StructDefinition(node) => self.struct_definitions.get(node),
-            ASTNode::StructuredDocumentation(node) => self.structured_documentations.get(node),
-            ASTNode::TryStatement(node) => self.try_statements.get(node),
-            ASTNode::TryCatchClause(node) => self.try_catch_clauses.get(node),
-            ASTNode::TupleExpression(node) => self.tuple_expressions.get(node),
-            ASTNode::UnaryOperation(node) => self.unary_operations.get(node),
-            ASTNode::UserDefinedTypeName(node) => self.user_defined_type_names.get(node),
-            ASTNode::UserDefinedValueTypeDefinition(node) => {
-                self.user_defined_value_type_definitions.get(node)
-            }
-            ASTNode::UsingForDirective(node) => self.using_for_directives.get(node),
-            ASTNode::VariableDeclaration(node) => self.variable_declarations.get(node),
-            ASTNode::VariableDeclarationStatement(node) => {
-                self.variable_declaration_statements.get(node)
-            }
-            ASTNode::WhileStatement(node) => self.while_statements.get(node),
+            ASTNode::ArrayTypeName(node) => self
+                .array_type_names
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::Assignment(node) => self
+                .assignments
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::BinaryOperation(node) => self
+                .binary_operations
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::Block(node) => self
+                .blocks
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::Conditional(node) => self
+                .conditionals
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::ContractDefinition(node) => self
+                .contract_definitions
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::ElementaryTypeName(node) => self
+                .elementary_type_names
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::ElementaryTypeNameExpression(node) => self
+                .elementary_type_name_expressions
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::EmitStatement(node) => self
+                .emit_statements
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::EnumDefinition(node) => self
+                .enum_definitions
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::EnumValue(node) => self
+                .enum_values
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::EventDefinition(node) => self
+                .event_definitions
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::ErrorDefinition(node) => self
+                .error_definitions
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::ExpressionStatement(node) => self
+                .expression_statements
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::FunctionCall(node) => self
+                .function_calls
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::FunctionCallOptions(node) => self
+                .function_call_options
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::FunctionDefinition(node) => self
+                .function_definitions
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::FunctionTypeName(node) => self
+                .function_type_names
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::ForStatement(node) => self
+                .for_statements
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::Identifier(node) => self
+                .identifiers
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::IdentifierPath(node) => self
+                .identifier_paths
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::IfStatement(node) => self
+                .if_statements
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::ImportDirective(node) => self
+                .import_directives
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::IndexAccess(node) => self
+                .index_accesses
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::IndexRangeAccess(node) => self
+                .index_range_accesses
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::InheritanceSpecifier(node) => self
+                .inheritance_specifiers
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::InlineAssembly(node) => self
+                .inline_assemblies
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::Literal(node) => self
+                .literals
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::MemberAccess(node) => self
+                .member_accesses
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::NewExpression(node) => self
+                .new_expressions
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::Mapping(node) => self
+                .mappings
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::ModifierDefinition(node) => self
+                .modifier_definitions
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::ModifierInvocation(node) => self
+                .modifier_invocations
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::OverrideSpecifier(node) => self
+                .override_specifiers
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::ParameterList(node) => self
+                .parameter_lists
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::PragmaDirective(node) => self
+                .pragma_directives
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::Return(node) => self
+                .returns
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::RevertStatement(node) => self
+                .revert_statements
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::SourceUnit(node) => Some(node.id),
+            ASTNode::StructDefinition(node) => self
+                .struct_definitions
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::StructuredDocumentation(node) => self
+                .structured_documentations
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::TryStatement(node) => self
+                .try_statements
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::TryCatchClause(node) => self
+                .try_catch_clauses
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::TupleExpression(node) => self
+                .tuple_expressions
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::UnaryOperation(node) => self
+                .unary_operations
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::UserDefinedTypeName(node) => self
+                .user_defined_type_names
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::UserDefinedValueTypeDefinition(node) => self
+                .user_defined_value_type_definitions
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::UsingForDirective(node) => self
+                .using_for_directives
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::VariableDeclaration(node) => self
+                .variable_declarations
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::VariableDeclarationStatement(node) => self
+                .variable_declaration_statements
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
+            ASTNode::WhileStatement(node) => self
+                .while_statements
+                .get(node)
+                .and_then(|context| Some(context.source_unit_id)),
         };
 
         // iterate through self.source_units until the source unit with the id matching `source_unit_id` is found, then return its `absolute_path`
 
-        source_unit_id.and_then(|&id| {
+        source_unit_id.and_then(|id| {
             self.source_units
                 .iter()
                 .find(|source_unit| source_unit.id == id)
@@ -276,52 +432,108 @@ impl ContextLoader {
 
 impl ASTConstVisitor for ContextLoader {
     fn visit_array_type_name(&mut self, node: &ArrayTypeName) -> Result<bool> {
-        self.array_type_names
-            .insert(node.clone(), self.last_source_unit_id);
+        self.array_type_names.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_assignment(&mut self, node: &Assignment) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::Assignment(node.clone()));
-        self.assignments
-            .insert(node.clone(), self.last_source_unit_id);
+        self.assignments.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_binary_operation(&mut self, node: &BinaryOperation) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::BinaryOperation(node.clone()));
-        self.binary_operations
-            .insert(node.clone(), self.last_source_unit_id);
+        self.binary_operations.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_block(&mut self, node: &Block) -> Result<bool> {
         self.nodes.insert(node.id, ASTNode::Block(node.clone()));
-        self.blocks.insert(node.clone(), self.last_source_unit_id);
+        self.blocks.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_conditional(&mut self, node: &Conditional) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::Conditional(node.clone()));
-        self.conditionals
-            .insert(node.clone(), self.last_source_unit_id);
+        self.conditionals.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_contract_definition(&mut self, node: &ContractDefinition) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::ContractDefinition(node.clone()));
-        self.contract_definitions
-            .insert(node.clone(), self.last_source_unit_id);
+        self.contract_definitions.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
+        self.last_contract_definition_id = Some(node.id);
         Ok(true)
     }
 
+    fn end_visit_contract_definition(&mut self, _: &ContractDefinition) -> Result<()> {
+        self.last_contract_definition_id = None;
+        Ok(())
+    }
+
     fn visit_elementary_type_name(&mut self, node: &ElementaryTypeName) -> Result<bool> {
-        self.elementary_type_names
-            .insert(node.clone(), self.last_source_unit_id);
+        self.elementary_type_names.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
@@ -331,232 +543,464 @@ impl ASTConstVisitor for ContextLoader {
     ) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::ElementaryTypeNameExpression(node.clone()));
-        self.elementary_type_name_expressions
-            .insert(node.clone(), self.last_source_unit_id);
+        self.elementary_type_name_expressions.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_emit_statement(&mut self, node: &EmitStatement) -> Result<bool> {
-        self.emit_statements
-            .insert(node.clone(), self.last_source_unit_id);
+        self.emit_statements.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_enum_definition(&mut self, node: &EnumDefinition) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::EnumDefinition(node.clone()));
-        self.enum_definitions
-            .insert(node.clone(), self.last_source_unit_id);
+        self.enum_definitions.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_enum_value(&mut self, node: &EnumValue) -> Result<bool> {
         self.nodes.insert(node.id, ASTNode::EnumValue(node.clone()));
-        self.enum_values
-            .insert(node.clone(), self.last_source_unit_id);
+        self.enum_values.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_event_definition(&mut self, node: &EventDefinition) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::EventDefinition(node.clone()));
-        self.event_definitions
-            .insert(node.clone(), self.last_source_unit_id);
+        self.event_definitions.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_error_definition(&mut self, node: &ErrorDefinition) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::ErrorDefinition(node.clone()));
-        self.error_definitions
-            .insert(node.clone(), self.last_source_unit_id);
+        self.error_definitions.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_expression_statement(&mut self, node: &ExpressionStatement) -> Result<bool> {
-        self.expression_statements
-            .insert(node.clone(), self.last_source_unit_id);
+        self.expression_statements.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_function_call(&mut self, node: &FunctionCall) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::FunctionCall(node.clone()));
-        self.function_calls
-            .insert(node.clone(), self.last_source_unit_id);
+        self.function_calls.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_function_call_options(&mut self, node: &FunctionCallOptions) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::FunctionCallOptions(node.clone()));
-        self.function_call_options
-            .insert(node.clone(), self.last_source_unit_id);
+        self.function_call_options.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_function_definition(&mut self, node: &FunctionDefinition) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::FunctionDefinition(node.clone()));
-        self.function_definitions
-            .insert(node.clone(), self.last_source_unit_id);
+        self.function_definitions.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
+        self.last_function_definition_id = Some(node.id);
         Ok(true)
     }
 
+    fn end_visit_function_definition(&mut self, _: &FunctionDefinition) -> Result<()> {
+        self.last_function_definition_id = None;
+        Ok(())
+    }
+
     fn visit_function_type_name(&mut self, node: &FunctionTypeName) -> Result<bool> {
-        self.function_type_names
-            .insert(node.clone(), self.last_source_unit_id);
+        self.function_type_names.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_for_statement(&mut self, node: &ForStatement) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::ForStatement(node.clone()));
-        self.for_statements
-            .insert(node.clone(), self.last_source_unit_id);
+        self.for_statements.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_identifier(&mut self, node: &Identifier) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::Identifier(node.clone()));
-        self.identifiers
-            .insert(node.clone(), self.last_source_unit_id);
+        self.identifiers.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_identifier_path(&mut self, node: &IdentifierPath) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::IdentifierPath(node.clone()));
-        self.identifier_paths
-            .insert(node.clone(), self.last_source_unit_id);
+        self.identifier_paths.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_if_statement(&mut self, node: &IfStatement) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::IfStatement(node.clone()));
-        self.if_statements
-            .insert(node.clone(), self.last_source_unit_id);
+        self.if_statements.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_import_directive(&mut self, node: &ImportDirective) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::ImportDirective(node.clone()));
-        self.import_directives
-            .insert(node.clone(), self.last_source_unit_id);
+        self.import_directives.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_index_access(&mut self, node: &IndexAccess) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::IndexAccess(node.clone()));
-        self.index_accesses
-            .insert(node.clone(), self.last_source_unit_id);
+        self.index_accesses.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_index_range_access(&mut self, node: &IndexRangeAccess) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::IndexRangeAccess(node.clone()));
-        self.index_range_accesses
-            .insert(node.clone(), self.last_source_unit_id);
+        self.index_range_accesses.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_inheritance_specifier(&mut self, node: &InheritanceSpecifier) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::InheritanceSpecifier(node.clone()));
-        self.inheritance_specifiers
-            .insert(node.clone(), self.last_source_unit_id);
+        self.inheritance_specifiers.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_inline_assembly(&mut self, node: &InlineAssembly) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::InlineAssembly(node.clone()));
-        self.inline_assemblies
-            .insert(node.clone(), self.last_source_unit_id);
+        self.inline_assemblies.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_literal(&mut self, node: &Literal) -> Result<bool> {
         self.nodes.insert(node.id, ASTNode::Literal(node.clone()));
-        self.literals.insert(node.clone(), self.last_source_unit_id);
+        self.literals.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_member_access(&mut self, node: &MemberAccess) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::MemberAccess(node.clone()));
-        self.member_accesses
-            .insert(node.clone(), self.last_source_unit_id);
+        self.member_accesses.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_new_expression(&mut self, node: &NewExpression) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::NewExpression(node.clone()));
-        self.new_expressions
-            .insert(node.clone(), self.last_source_unit_id);
+        self.new_expressions.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_mapping(&mut self, node: &Mapping) -> Result<bool> {
-        self.mappings.insert(node.clone(), self.last_source_unit_id);
+        self.mappings.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_modifier_definition(&mut self, node: &ModifierDefinition) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::ModifierDefinition(node.clone()));
-        self.modifier_definitions
-            .insert(node.clone(), self.last_source_unit_id);
+        self.modifier_definitions.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
+        self.last_modifier_definition_id = Some(node.id);
         Ok(true)
+    }
+
+    fn end_visit_modifier_definition(&mut self, _: &ModifierDefinition) -> Result<()> {
+        self.last_modifier_definition_id = None;
+        Ok(())
     }
 
     fn visit_modifier_invocation(&mut self, node: &ModifierInvocation) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::ModifierInvocation(node.clone()));
-        self.modifier_invocations
-            .insert(node.clone(), self.last_source_unit_id);
+        self.modifier_invocations.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_override_specifier(&mut self, node: &OverrideSpecifier) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::OverrideSpecifier(node.clone()));
-        self.override_specifiers
-            .insert(node.clone(), self.last_source_unit_id);
+        self.override_specifiers.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_parameter_list(&mut self, node: &ParameterList) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::ParameterList(node.clone()));
-        self.parameter_lists
-            .insert(node.clone(), self.last_source_unit_id);
+        self.parameter_lists.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_pragma_directive(&mut self, node: &PragmaDirective) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::PragmaDirective(node.clone()));
-        self.pragma_directives
-            .insert(node.clone(), self.last_source_unit_id);
+        self.pragma_directives.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_return(&mut self, node: &Return) -> Result<bool> {
         self.nodes.insert(node.id, ASTNode::Return(node.clone()));
-        self.returns.insert(node.clone(), self.last_source_unit_id);
+        self.returns.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_revert_statement(&mut self, node: &RevertStatement) -> Result<bool> {
-        self.revert_statements
-            .insert(node.clone(), self.last_source_unit_id);
+        self.revert_statements.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
@@ -571,50 +1015,99 @@ impl ASTConstVisitor for ContextLoader {
     fn visit_struct_definition(&mut self, node: &StructDefinition) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::StructDefinition(node.clone()));
-        self.struct_definitions
-            .insert(node.clone(), self.last_source_unit_id);
+        self.struct_definitions.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_structured_documentation(&mut self, node: &StructuredDocumentation) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::StructuredDocumentation(node.clone()));
-        self.structured_documentations
-            .insert(node.clone(), self.last_source_unit_id);
+        self.structured_documentations.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_try_statement(&mut self, node: &TryStatement) -> Result<bool> {
-        self.try_statements
-            .insert(node.clone(), self.last_source_unit_id);
+        self.try_statements.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_try_catch_clause(&mut self, node: &TryCatchClause) -> Result<bool> {
-        self.try_catch_clauses
-            .insert(node.clone(), self.last_source_unit_id);
+        self.try_catch_clauses.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_tuple_expression(&mut self, node: &TupleExpression) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::TupleExpression(node.clone()));
-        self.tuple_expressions
-            .insert(node.clone(), self.last_source_unit_id);
+        self.tuple_expressions.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_unary_operation(&mut self, node: &UnaryOperation) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::UnaryOperation(node.clone()));
-        self.unary_operations
-            .insert(node.clone(), self.last_source_unit_id);
+        self.unary_operations.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_user_defined_type_name(&mut self, node: &UserDefinedTypeName) -> Result<bool> {
-        self.user_defined_type_names
-            .insert(node.clone(), self.last_source_unit_id);
+        self.user_defined_type_names.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
@@ -626,24 +1119,45 @@ impl ASTConstVisitor for ContextLoader {
             node.id,
             ASTNode::UserDefinedValueTypeDefinition(node.clone()),
         );
-        self.user_defined_value_type_definitions
-            .insert(node.clone(), self.last_source_unit_id);
+        self.user_defined_value_type_definitions.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_using_for_directive(&mut self, node: &UsingForDirective) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::UsingForDirective(node.clone()));
-        self.using_for_directives
-            .insert(node.clone(), self.last_source_unit_id);
+        self.using_for_directives.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_variable_declaration(&mut self, node: &VariableDeclaration) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::VariableDeclaration(node.clone()));
-        self.variable_declarations
-            .insert(node.clone(), self.last_source_unit_id);
+        self.variable_declarations.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
@@ -653,16 +1167,30 @@ impl ASTConstVisitor for ContextLoader {
     ) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::VariableDeclarationStatement(node.clone()));
-        self.variable_declaration_statements
-            .insert(node.clone(), self.last_source_unit_id);
+        self.variable_declaration_statements.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 
     fn visit_while_statement(&mut self, node: &WhileStatement) -> Result<bool> {
         self.nodes
             .insert(node.id, ASTNode::WhileStatement(node.clone()));
-        self.while_statements
-            .insert(node.clone(), self.last_source_unit_id);
+        self.while_statements.insert(
+            node.clone(),
+            NodeContext {
+                source_unit_id: self.last_source_unit_id,
+                contract_definition_id: self.last_contract_definition_id,
+                function_definition_id: self.last_function_definition_id,
+                modifier_definition_id: self.last_modifier_definition_id,
+            },
+        );
         Ok(true)
     }
 }

--- a/aderyn_core/src/detect/high/delegate_call_in_loop.rs
+++ b/aderyn_core/src/detect/high/delegate_call_in_loop.rs
@@ -4,7 +4,7 @@ use std::error::Error;
 use crate::{
     ast::MemberAccess,
     context::{
-        browser::MemberAccessExtractor,
+        browser::ExtractMemberAccesss,
         loader::{ASTNode, ContextLoader},
     },
     detect::detector::{Detector, IssueSeverity},
@@ -23,7 +23,7 @@ impl Detector for DelegateCallInLoopDetector {
 
         // Get all delegatecall member accesses inside for statements
         member_accesses.extend(loader.for_statements.keys().flat_map(|statement| {
-            MemberAccessExtractor::extract_from(statement)
+            ExtractMemberAccesss::from(statement)
                 .extracted
                 .into_iter()
                 .filter(|ma| ma.member_name == "delegatecall")
@@ -31,7 +31,7 @@ impl Detector for DelegateCallInLoopDetector {
 
         // Get all delegatecall member accsesses inside while statements
         member_accesses.extend(loader.while_statements.keys().flat_map(|statement| {
-            MemberAccessExtractor::extract_from(statement)
+            ExtractMemberAccesss::from(statement)
                 .extracted
                 .into_iter()
                 .filter(|ma| ma.member_name == "delegatecall")

--- a/aderyn_core/src/detect/high/delegate_call_in_loop.rs
+++ b/aderyn_core/src/detect/high/delegate_call_in_loop.rs
@@ -23,7 +23,7 @@ impl Detector for DelegateCallInLoopDetector {
 
         // Get all delegatecall member accesses inside for statements
         member_accesses.extend(loader.for_statements.keys().flat_map(|statement| {
-            MemberAccessExtractor::from_node(statement)
+            MemberAccessExtractor::extract_from(statement)
                 .extracted
                 .into_iter()
                 .filter(|ma| ma.member_name == "delegatecall")
@@ -31,7 +31,7 @@ impl Detector for DelegateCallInLoopDetector {
 
         // Get all delegatecall member accsesses inside while statements
         member_accesses.extend(loader.while_statements.keys().flat_map(|statement| {
-            MemberAccessExtractor::from_node(statement)
+            MemberAccessExtractor::extract_from(statement)
                 .extracted
                 .into_iter()
                 .filter(|ma| ma.member_name == "delegatecall")

--- a/aderyn_core/src/detect/high/delegate_call_in_loop.rs
+++ b/aderyn_core/src/detect/high/delegate_call_in_loop.rs
@@ -4,7 +4,7 @@ use std::error::Error;
 use crate::{
     ast::MemberAccess,
     context::{
-        browser::ExtractMemberAccesss,
+        browser::ExtractMemberAccesses,
         loader::{ASTNode, ContextLoader},
     },
     detect::detector::{Detector, IssueSeverity},
@@ -23,7 +23,7 @@ impl Detector for DelegateCallInLoopDetector {
 
         // Get all delegatecall member accesses inside for statements
         member_accesses.extend(loader.for_statements.keys().flat_map(|statement| {
-            ExtractMemberAccesss::from(statement)
+            ExtractMemberAccesses::from(statement)
                 .extracted
                 .into_iter()
                 .filter(|ma| ma.member_name == "delegatecall")
@@ -31,7 +31,7 @@ impl Detector for DelegateCallInLoopDetector {
 
         // Get all delegatecall member accsesses inside while statements
         member_accesses.extend(loader.while_statements.keys().flat_map(|statement| {
-            ExtractMemberAccesss::from(statement)
+            ExtractMemberAccesses::from(statement)
                 .extracted
                 .into_iter()
                 .filter(|ma| ma.member_name == "delegatecall")

--- a/aderyn_core/src/detect/medium/unsafe_oz_erc721_mint.rs
+++ b/aderyn_core/src/detect/medium/unsafe_oz_erc721_mint.rs
@@ -1,7 +1,10 @@
 use std::{collections::BTreeMap, error::Error};
 
 use crate::{
-    context::loader::{ASTNode, ContextLoader},
+    context::{
+        browser::GetParent,
+        loader::{ASTNode, ContextLoader},
+    },
     detect::detector::{Detector, IssueSeverity},
 };
 use eyre::Result;
@@ -17,9 +20,7 @@ impl Detector for UnsafeERC721MintDetector {
         for identifier in loader.identifiers.keys() {
             // if source_unit has any ImportDirectives with absolute_path containing "openzeppelin"
             // call identifier.accept(self)
-            let source_unit = loader
-                .get_source_unit_from_child_node(&ASTNode::Identifier(identifier.clone()))
-                .unwrap();
+            let source_unit = GetParent::source_unit_of(identifier, loader).unwrap();
 
             let import_directives = source_unit.import_directives();
             if import_directives.iter().any(|directive| {

--- a/aderyn_core/src/detect/nc/constants_instead_of_literals.rs
+++ b/aderyn_core/src/detect/nc/constants_instead_of_literals.rs
@@ -22,7 +22,7 @@ impl Detector for ConstantsInsteadOfLiteralsDetector {
         // for each function definition, find all Literal types
         // if the literal type is either a Number, HexString or Address, then add it to the list of found literals
         for function_definition in loader.function_definitions.keys() {
-            LiteralExtractor::from_node(function_definition)
+            LiteralExtractor::extract_from(function_definition)
                 .extracted
                 .iter()
                 .for_each(|literal| {

--- a/aderyn_core/src/detect/nc/constants_instead_of_literals.rs
+++ b/aderyn_core/src/detect/nc/constants_instead_of_literals.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeMap, error::Error};
 use crate::{
     ast::LiteralKind,
     context::{
-        browser::LiteralExtractor,
+        browser::ExtractLiterals,
         loader::{ASTNode, ContextLoader},
     },
     detect::detector::{Detector, IssueSeverity},
@@ -22,7 +22,7 @@ impl Detector for ConstantsInsteadOfLiteralsDetector {
         // for each function definition, find all Literal types
         // if the literal type is either a Number, HexString or Address, then add it to the list of found literals
         for function_definition in loader.function_definitions.keys() {
-            LiteralExtractor::extract_from(function_definition)
+            ExtractLiterals::from(function_definition)
                 .extracted
                 .iter()
                 .for_each(|literal| {

--- a/aderyn_core/src/detect/nc/zero_address_check.rs
+++ b/aderyn_core/src/detect/nc/zero_address_check.rs
@@ -56,7 +56,7 @@ impl Detector for ZeroAddressCheckDetector {
         for function_definition in loader.function_definitions.keys() {
             // Get all the binary checks inside the function
             let binary_operations: Vec<BinaryOperation> =
-                BinaryOperationExtractor::from_node(function_definition)
+                BinaryOperationExtractor::extract_from(function_definition)
                     .extracted
                     .into_iter()
                     .filter(|x| x.operator == "==" || x.operator == "!=")
@@ -92,7 +92,7 @@ impl Detector for ZeroAddressCheckDetector {
             }
 
             // Get all the assignments in the function
-            let assignments = AssignmentExtractor::from_node(function_definition)
+            let assignments = AssignmentExtractor::extract_from(function_definition)
                 .extracted
                 .into_iter()
                 .filter(|x| {

--- a/aderyn_core/src/detect/nc/zero_address_check.rs
+++ b/aderyn_core/src/detect/nc/zero_address_check.rs
@@ -6,7 +6,7 @@ use std::{
 use crate::{
     ast::{BinaryOperation, Expression, Mutability, NodeID, VariableDeclaration},
     context::{
-        browser::{AssignmentExtractor, BinaryOperationExtractor},
+        browser::{ExtractAssignments, ExtractBinaryOperations},
         loader::{ASTNode, ContextLoader},
     },
     detect::detector::{Detector, IssueSeverity},
@@ -56,7 +56,7 @@ impl Detector for ZeroAddressCheckDetector {
         for function_definition in loader.function_definitions.keys() {
             // Get all the binary checks inside the function
             let binary_operations: Vec<BinaryOperation> =
-                BinaryOperationExtractor::extract_from(function_definition)
+                ExtractBinaryOperations::from(function_definition)
                     .extracted
                     .into_iter()
                     .filter(|x| x.operator == "==" || x.operator == "!=")
@@ -92,7 +92,7 @@ impl Detector for ZeroAddressCheckDetector {
             }
 
             // Get all the assignments in the function
-            let assignments = AssignmentExtractor::extract_from(function_definition)
+            let assignments = ExtractAssignments::from(function_definition)
                 .extracted
                 .into_iter()
                 .filter(|x| {


### PR DESCRIPTION
Sort of Fixes #115 .

When the `ContextLoader` initially builds context, it keeps track of each Node's `SourceUnit`, `ContractDefinition`, `FunctionDefinition` and `ModifierDefinition`. The `parents` module then provides a framework to get a parent of these types.

For example, let's say we have an expression, and we want to get it's parent contract:

```rs
let contract_definition: &ContractDefinition = GetParent::contract_definition_of(my_expression, context_loader).unwrap();
```

Similarly, the extractor pattern can get the expressions from the contract definition (implemented in #120 ):

```rs
let expressions: Vec<Expression> = ExtractExpressions::from(contract_definition).extracted;
```