### PR TITLE
Non reentrant modifier name detection is more generalized

### DIFF
--- a/aderyn_core/src/detect/low/non_reentrant_before_others.rs
+++ b/aderyn_core/src/detect/low/non_reentrant_before_others.rs
@@ -20,7 +20,13 @@ impl IssueDetector for NonReentrantBeforeOthersDetector {
         for definition in function_definitions {
             if definition.modifiers.len() > 1 {
                 for (index, modifier) in definition.modifiers.iter().enumerate() {
-                    if modifier.modifier_name.name == "nonReentrant" && index != 0 {
+                    if modifier
+                        .modifier_name
+                        .name
+                        .to_lowercase()
+                        .contains("nonreentrant")
+                        && index != 0
+                    {
                         capture!(self, context, modifier);
                     }
                 }


### PR DESCRIPTION
Some codebases like [gmx](https://github.com/gmx-io/gmx-synthetics/blob/bb3d56c68cb66975d344e59c5f4f3e2f9ba8bb95/contracts/exchange/DepositHandler.sol#L51)  uses `globalNonReentrant` as modifier names so this PR is an attempt to generalize such cases