### PR TITLE
Unprotected Init function are unprotected if there are no `only` modifiers (having other kinds of modifiers still leaves the function unprotected)

### DIFF
--- a/aderyn_core/src/detect/high/unprotected_init_function.rs
+++ b/aderyn_core/src/detect/high/unprotected_init_function.rs
@@ -19,7 +19,11 @@ impl IssueDetector for UnprotectedInitializerDetector {
         for function in context.function_definitions() {
             if function.name.to_lowercase().contains("init") {
                 let has_modifiers = !function.modifiers.is_empty();
-                if !has_modifiers {
+                let has_non_reentrant_modifier = function
+                    .modifiers
+                    .iter()
+                    .any(|m| m.modifier_name.name.to_lowercase().contains("nonreentrant"));
+                if !has_modifiers || (function.modifiers.len() == 1 && has_non_reentrant_modifier) {
                     let identifiers = ExtractIdentifiers::from(function).extracted;
                     if !identifiers
                         .iter()


### PR DESCRIPTION
We expected the Unprotected Init function to be fixed by having something like `onlyAccountManagers`, `onlySmartVaultManager`, etc... Wheras If the modifier is `nonReentrant` then we say it is still unprotected. (It protects re-entrancy but the authorization protection is still absent)

so we should look for modifiers with `only` in the name