### PR TITLE
Fix: peek panics

### DIFF
--- a/aderyn_core/src/context/browser/peek_over.rs
+++ b/aderyn_core/src/context/browser/peek_over.rs
@@ -39,12 +39,19 @@ impl<T: Node + ?Sized> PeekOver for T {
         if let Some(previous_sibling) = self.previous_sibling(context) {
             let (prev_offset, prev_len) =
                 context.get_offset_and_length_of_node(previous_sibling.id()?)?;
-            let requried_content = &content[prev_offset + prev_len..curr_offset];
-            return Some(requried_content.to_string());
+            if prev_offset + prev_len < curr_offset && curr_offset < content.len() {
+                let requried_content = &content[prev_offset + prev_len..curr_offset];
+                return Some(requried_content.to_string());
+            }
         }
 
         // If there is no previous sibling we must return content from the top of the file
-        let requried_content = &content[0..curr_offset];
-        Some(requried_content.to_string())
+
+        if curr_offset < content.len() {
+            let requried_content = &content[0..curr_offset];
+            return Some(requried_content.to_string());
+        }
+
+        None
     }
 }

--- a/aderyn_core/src/context/browser/peek_over.rs
+++ b/aderyn_core/src/context/browser/peek_over.rs
@@ -42,6 +42,8 @@ impl<T: Node + ?Sized> PeekOver for T {
             if prev_offset + prev_len < curr_offset && curr_offset < content.len() {
                 let requried_content = &content[prev_offset + prev_len..curr_offset];
                 return Some(requried_content.to_string());
+            } else {
+                return None;
             }
         }
 

--- a/aderyn_core/src/context/browser/peek_under.rs
+++ b/aderyn_core/src/context/browser/peek_under.rs
@@ -38,8 +38,10 @@ impl<T: Node + ?Sized> PeekUnder for T {
 
         if let Some(next_sibling) = self.next_sibling(context) {
             let (next_offset, _) = context.get_offset_and_length_of_node(next_sibling.id()?)?;
-            let requried_content = &content[curr_offset + curr_len..next_offset];
-            return Some(requried_content.to_string());
+            if curr_offset + curr_len < next_offset && next_offset < content.len() {
+                let requried_content = &content[curr_offset + curr_len..next_offset];
+                return Some(requried_content.to_string());
+            }
         }
 
         // If there is no next sibling we must content til the bottom of the file

--- a/aderyn_core/src/context/browser/peek_under.rs
+++ b/aderyn_core/src/context/browser/peek_under.rs
@@ -41,6 +41,8 @@ impl<T: Node + ?Sized> PeekUnder for T {
             if curr_offset + curr_len < next_offset && next_offset < content.len() {
                 let requried_content = &content[curr_offset + curr_len..next_offset];
                 return Some(requried_content.to_string());
+            } else {
+                return None;
             }
         }
 

--- a/aderyn_core/src/context/workspace_context.rs
+++ b/aderyn_core/src/context/workspace_context.rs
@@ -1251,8 +1251,10 @@ impl WorkspaceContext {
             let offset: usize = offset.parse().ok()?;
             let len: usize = len.parse().ok()?;
             if let Some(content) = source_unit.source.as_ref() {
-                let requried_content = &content[offset..offset + len];
-                return Some(requried_content.to_string());
+                if offset + len < content.len() {
+                    let requried_content = &content[offset..offset + len];
+                    return Some(requried_content.to_string());
+                }
             }
         }
         None


### PR DESCRIPTION
Sometimes for node properties `offset`, `len` can have values like `-1` 

That's why it's important we check the bounds before we return the string

Fix for https://github.com/Cyfrin/aderyn/issues/369