### PR TITLE
Cargo clippy lint update

### DIFF
--- a/judgeops/src/watchtower/mod.rs
+++ b/judgeops/src/watchtower/mod.rs
@@ -50,6 +50,7 @@ pub trait RegistersNewDetector {
     fn register(&self, detector_name: String, assigned_severity: IssueSeverity);
 }
 
+#[allow(dead_code)]
 pub trait UnregistersDetector {
     fn unregister_detector(&self, detector_name: String);
 }


### PR DESCRIPTION
There was 1 trait that we don't technically use, so marked it `#allow(dead_code)`  for now

PS: I do believe that as the detectors grow in number we will find this watchtower useful for qualitative analysis. (Just like benchmarks for quantitative analysis)

For now, our focus is towards stuff like framework independence, extension, etc. 

