### PR TITLE
use foundry compilers utils::canonicalize 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,7 @@ version = "0.0.26"
 dependencies = [
  "aderyn_driver",
  "clap",
+ "foundry-compilers 0.3.20",
  "notify-debouncer-full",
  "reqwest",
  "semver 1.0.23",

--- a/aderyn/Cargo.toml
+++ b/aderyn/Cargo.toml
@@ -18,4 +18,5 @@ serde = { version = "1.0.160", features = ["derive"] }
 serde_json = { version = "1.0.96", features = ["preserve_order"] }
 strum = { version = "0.26", features = ["derive"] }
 notify-debouncer-full = "0.3.1"
+foundry-compilers = { git = "https://github.com/Cyfrin/foundry-compilers", features = ["svm-solc"], branch = "aderyn/icf" }
 

--- a/aderyn/src/main.rs
+++ b/aderyn/src/main.rs
@@ -23,6 +23,8 @@ use notify_debouncer_full::{
     notify::{RecursiveMode, Watcher},
 };
 
+use foundry_compilers::utils;
+
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct CommandLineArgs {
@@ -185,7 +187,7 @@ fn main() {
                     scope_file_path.pop();
                     scope_file_path.push(PathBuf::from(scope_file));
 
-                    let canonicalized_scope_file_path = std::fs::canonicalize(&scope_file_path);
+                    let canonicalized_scope_file_path = utils::canonicalize(&scope_file_path);
                     match canonicalized_scope_file_path {
                         Ok(ok_scope_file_path) => {
                             assert!(ok_scope_file_path.exists());

--- a/aderyn_core/src/detect/test_utils/mod.rs
+++ b/aderyn_core/src/detect/test_utils/mod.rs
@@ -1,6 +1,7 @@
 mod load_contract;
 mod load_source_unit;
 
+use foundry_compilers::utils;
 use once_cell::sync::Lazy;
 use std::path::PathBuf;
 
@@ -36,5 +37,5 @@ fn ensure_valid_solidity_file(filepath: &str) -> PathBuf {
         std::process::exit(1);
     }
 
-    filepath.canonicalize().unwrap()
+    utils::canonicalize(filepath).unwrap()
 }

--- a/aderyn_core/src/framework/foundry.rs
+++ b/aderyn_core/src/framework/foundry.rs
@@ -1,9 +1,10 @@
 use crate::ast::*;
 use eyre::Result;
+use foundry_compilers::utils;
 use serde::{Deserialize, Serialize};
 
 use std::error::Error;
-use std::fs::{canonicalize, read_dir, read_to_string, File};
+use std::fs::{read_dir, read_to_string, File};
 use std::io::BufReader;
 use std::path::PathBuf;
 use std::process::Stdio;
@@ -41,7 +42,7 @@ pub fn load_foundry(
     foundry_root: &PathBuf,
     skip_build: bool,
 ) -> Result<LoadedFoundry, Box<dyn Error>> {
-    let foundry_root_absolute = canonicalize(foundry_root).unwrap_or_else(|err| {
+    let foundry_root_absolute = utils::canonicalize(foundry_root).unwrap_or_else(|err| {
         // Exit with a non-zero exit code
         eprintln!("Error getting absolute path of Foundry root directory");
         // print err

--- a/aderyn_driver/src/foundry_compiler_helpers.rs
+++ b/aderyn_driver/src/foundry_compiler_helpers.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use foundry_compilers::{
-    artifacts::Source, remappings::Remapping, CompilerInput, Project, ProjectPathsConfig,
+    artifacts::Source, remappings::Remapping, utils, CompilerInput, Project, ProjectPathsConfig,
 };
 
 use crate::{passes_exclude, passes_scope, passes_src, read_remappings};
@@ -70,19 +70,19 @@ pub fn get_relevant_sources(
         .sources
         .iter()
         .filter(|(solidity_file, _)| {
-            passes_src(src, solidity_file.canonicalize().unwrap().as_path())
+            passes_src(src, utils::canonicalize(solidity_file).unwrap().as_path())
         })
         .filter(|(solidity_file, _)| {
             passes_scope(
                 scope,
-                solidity_file.canonicalize().unwrap().as_path(),
+                utils::canonicalize(solidity_file).unwrap().as_path(),
                 root.to_string_lossy().as_ref(),
             )
         })
         .filter(|(solidity_file, _)| {
             passes_exclude(
                 exclude,
-                solidity_file.canonicalize().unwrap().as_path(),
+                utils::canonicalize(solidity_file).unwrap().as_path(),
                 root.to_string_lossy().as_ref(),
             )
         })
@@ -99,18 +99,20 @@ pub fn get_relevant_pathbufs(
 ) -> Vec<PathBuf> {
     pathbufs
         .iter()
-        .filter(|solidity_file| passes_src(src, solidity_file.canonicalize().unwrap().as_path()))
+        .filter(|solidity_file| {
+            passes_src(src, utils::canonicalize(solidity_file).unwrap().as_path())
+        })
         .filter(|solidity_file| {
             passes_scope(
                 scope,
-                solidity_file.canonicalize().unwrap().as_path(),
+                utils::canonicalize(solidity_file).unwrap().as_path(),
                 root.to_string_lossy().as_ref(),
             )
         })
         .filter(|solidity_file| {
             passes_exclude(
                 exclude,
-                solidity_file.canonicalize().unwrap().as_path(),
+                utils::canonicalize(solidity_file).unwrap().as_path(),
                 root.to_string_lossy().as_ref(),
             )
         })

--- a/aderyn_driver/src/lib.rs
+++ b/aderyn_driver/src/lib.rs
@@ -11,6 +11,7 @@ pub use aderyn_core::context;
 pub use aderyn_core::detect as detection_modules;
 pub use aderyn_core::detect::detector;
 pub use foundry_compiler_helpers::*;
+use foundry_compilers::utils;
 pub use process_auto::with_project_root_at;
 
 fn ensure_valid_root_path(root_path: &Path) -> PathBuf {
@@ -18,7 +19,7 @@ fn ensure_valid_root_path(root_path: &Path) -> PathBuf {
         eprintln!("{} does not exist!", root_path.to_string_lossy());
         std::process::exit(1);
     }
-    root_path.canonicalize().unwrap()
+    utils::canonicalize(root_path).unwrap()
 }
 
 fn passes_src(src: &Option<Vec<PathBuf>>, solidity_file: &Path) -> bool {

--- a/aderyn_driver/src/process_auto.rs
+++ b/aderyn_driver/src/process_auto.rs
@@ -125,15 +125,21 @@ fn create_workspace_context_from_stdout(
             let filepath = &PathBuf::from(&line["======= ".len()..end_marker]);
             if passes_scope(
                 scope,
-                root_path.join(filepath).canonicalize().unwrap().as_path(),
+                utils::canonicalize(root_path.join(filepath))
+                    .unwrap()
+                    .as_path(),
                 absolute_root_path_str,
             ) && passes_exclude(
                 exclude,
-                root_path.join(filepath).canonicalize().unwrap().as_path(),
+                utils::canonicalize(root_path.join(filepath))
+                    .unwrap()
+                    .as_path(),
                 absolute_root_path_str,
             ) && passes_src(
                 src,
-                root_path.join(filepath).canonicalize().unwrap().as_path(),
+                utils::canonicalize(root_path.join(filepath))
+                    .unwrap()
+                    .as_path(),
             ) {
                 src_filepaths.push(filepath.to_string_lossy().to_string());
                 pick_next_line = true;


### PR DESCRIPTION
Instead of using `std::fs::canonicalize` we should use this from foundry compiler's utils

Advantage:
> On windows this will ensure the path only consists of `/` separators

So this in my opinion is safer

```rust
/// Canonicalize the path, platform-agnostic
///
/// On windows this will ensure the path only consists of `/` separators
pub fn canonicalize(path: impl AsRef<Path>) -> Result<PathBuf, SolcIoError> {
    let path = path.as_ref();
    cfg_if! {
        if #[cfg(windows)] {
            let res = dunce::canonicalize(path).map(|p| {
                use path_slash::PathBufExt;
                PathBuf::from(p.to_slash_lossy().as_ref())
            });
        } else {
         let res = dunce::canonicalize(path);
        }
    };

    res.map_err(|err| SolcIoError::new(err, path))
}
```