### PR TITLE
CI Legacy reports generation workflow (when there is no `--icf` flag)

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -320,6 +320,19 @@ jobs:
           cat ./reports/report-config-workflow.json
           diff ./reports/report-config.json ./reports/report-config-workflow.json
 
+      # Verify sarif report
+
+      - name: Generate sarif report
+        uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: -- -o ./reports/ci-report.sarif ./tests/contract-playground/ --skip-update-check
+
+      - name: Check sarif report
+        run: |
+          cat ./reports/ci-report.sarif
+          diff ./reports/report.sarif ./reports/ci-report.sarif
+
 
   lints:
     name: Lints

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -232,6 +232,55 @@ jobs:
           cat ./reports/ci-report.sarif
           diff ./reports/report.sarif ./reports/ci-report.sarif
 
+  legacy_reports:
+    name: Check Reports (Legacy)
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: foundry-toolchain
+        uses: foundry-rs/foundry-toolchain@v1.2.0
+
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - uses: actions/checkout@v3
+
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 8
+
+      - name: Install git submodules
+        run: |
+          git submodule update --init --recursive
+
+      - name: Install pnpm dependencies for ccip contracts and come out
+        run: |
+          cd tests/ccip-contracts/
+          pnpm install
+          cd contracts/
+          pnpm install
+          cd ../../../
+
+      # Verify report.md
+
+      - name: Generate report-workflow.md
+        uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: -- -o ./reports/report-workflow.md ./tests/contract-playground/ --skip-update-check
+
+      - name: Check report.md vs report-workflow.md
+        run: |
+          cat ./reports/report-workflow.md
+          diff ./reports/report.md ./reports/report-workflow.md
+
   lints:
     name: Lints
     runs-on: ubuntu-latest

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -281,6 +281,46 @@ jobs:
           cat ./reports/report-workflow.md
           diff ./reports/report.md ./reports/report-workflow.md
 
+      # Verify report-config.md
+
+      - name: Generate report-config-workflow.md
+        uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: -- --config-file ./tests/aderyn.config.json -o ./reports/report-config-workflow.md ./tests/contract-playground/ --skip-update-check
+
+      - name: Check report-config.md vs report-config-workflow.md
+        run: |
+          cat ./reports/report-config-workflow.md
+          diff ./reports/report-config.md ./reports/report-config-workflow.md
+
+     # Verify report.json 
+
+      - name: Generate report-workflow.json
+        uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: -- -o ./reports/report-workflow.json ./tests/contract-playground/ --skip-update-check
+
+      - name: Check report.json vs report-workflow.json
+        run: |
+          cat ./reports/report-workflow.json
+          diff ./reports/report.json ./reports/report-workflow.json
+
+      # Verify report-config.json
+
+      - name: Generate report-config-workflow.json
+        uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: -- --config-file ./tests/aderyn.config.json -o ./reports/report-config-workflow.json ./tests/contract-playground/ --skip-update-check
+
+      - name: Check report-config.json vs report-config-workflow.json
+        run: |
+          cat ./reports/report-config-workflow.json
+          diff ./reports/report-config.json ./reports/report-config-workflow.json
+
+
   lints:
     name: Lints
     runs-on: ubuntu-latest


### PR DESCRIPTION
There is a new job in CI called `Check Reports (Legacy)` 

That's where all the current dev tests should go.

cc: @alexroan 