### PR TITLE
MacOS: x86_64 binary - use macos with intel chip as runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
             runner: windows-latest
             target: x86_64-pc-windows-msvc
           - name: macos-amd64
-            runner: macos-latest
+            runner: macos-latest-large
             target: x86_64-apple-darwin
           - name: macos-arm64
             runner: macos-latest


### PR DESCRIPTION
Reference - 
https://github.com/actions/runner-images?tab=readme-ov-file

Currently, we are building x86_64 binaries in an arm64 based mac runner. Plausible cause for #557 

So this PR changes the runner to an intel based mac based on the reference above