### PR TITLE
Fix `VariableDeclaration::mutability` default and invalid digit for `byteoffset`

### DIFF
--- a/aderyn_core/src/ast/variables.rs
+++ b/aderyn_core/src/ast/variables.rs
@@ -105,14 +105,11 @@ impl VariableDeclaration {
     /// This is a helper to check variable mutability across Solidity versions.
     pub fn mutability(&self) -> &Mutability {
         if let Some(mutability) = &self.mutability {
-            mutability
+            return mutability;
         } else if self.constant {
-            &Mutability::Constant
-        } else if self.state_variable {
-            &Mutability::Mutable
-        } else {
-            unreachable!()
+            return &Mutability::Constant;
         }
+        &Mutability::Mutable
     }
 }
 

--- a/aderyn_core/src/report/mod.rs
+++ b/aderyn_core/src/report/mod.rs
@@ -103,8 +103,8 @@ pub fn extract_issue_bodies(
                 .map(|(contract_path, line_no, src_location)| {
                     // Calculate character based offset & length position here
                     let (byte_offset_str, byte_len_str) = src_location.split_once(':').unwrap();
-                    let byte_offset: usize = byte_offset_str.parse().unwrap();
-                    let byte_length: usize = byte_len_str.parse().unwrap();
+                    let byte_offset: usize = byte_offset_str.parse().unwrap_or_default();
+                    let byte_length: usize = byte_len_str.parse().unwrap_or_default();
                     let content = *file_contents.get(contract_path).unwrap();
                     let mut char_offset = 0;
                     for (byte_offset_so_far, _) in content.char_indices() {


### PR DESCRIPTION
Fixes #574 

*  Remove `unreachable!()` for `VariableDeclaration::mutability()` by defaulting to `Mutable`
* `byte_offset_str` can sometimes be "-1:-1" so when parsing to `usize` it fails! Fix  by defaulting it to `0:0` 