### PR TITLE
README: Remove cargo as a recommended install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,15 +59,11 @@ You can read the [Cyfrin official documentation](https://docs.cyfrin.io) for an 
 [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=dustypomerleau.rust-syntax) - Rust language support for Visual Studio Code
 [Rust Syntax](https://marketplace.visualstudio.com/items?itemName=dustypomerleau.rust-syntax) - Improved Rust syntax highlighting
 
-### Installing Aderyn
-
-You can install Aderyn using Cargo, Rust's package manager, or with `cyfrinup`, the Cyfrin CLI tool.
-
-#### Using Cyfrinup
+### Using Cyfrinup
 
 > Note: If you previously installed aderyn using cargo, run `cargo uninstall aderyn` before using `cyfrinup` to avoid conflicts.
 
-**Step 1: Install Cyfrinup**
+#### Step 1: Install Cyfrinup
 
 Cyfrinup is a CLI tool that simplifies the installation and management of Cyfrin tools. To install Cyfrinup, run the following command in your terminal:
 
@@ -75,11 +71,11 @@ Cyfrinup is a CLI tool that simplifies the installation and management of Cyfrin
 curl -L https://raw.githubusercontent.com/Cyfrin/aderyn/dev/cyfrinup/install | bash
 ```
 
-**Step 2: Update Path**
+#### Step 2: Update Path
 
 The installer will prompt you to run a `source` command. Either run this command, or reload your terminal.
 
-**Step 3: Install Aderyn using Cyfrinup**
+#### Step 3: Install Aderyn using Cyfrinup
 
 After installing Cyfrinup, you can use it to install Aderyn. Run the following command in your terminal:
 
@@ -87,56 +83,19 @@ After installing Cyfrinup, you can use it to install Aderyn. Run the following c
 cyfrinup
 ```
 
-**Step 4: Verify installation**
+#### Step 4: Verify installation
 
 ```sh
 aderyn --version
 ```
 
-**Future Updates**
+#### Future Updates
 
 To update Aderyn to the latest version, you can run the cyfrinup:
 ```sh
 cyfrinup
 ```
 Cyfrinup will replace the existing version with the latest one.
-
-
-#### Using Cargo
-
-**Step 1: Install Rust**
-
-Before installing Aderyn, ensure you have the following:
-* Rust: Aderyn is built in Rust. Before running, you must install Rust and Cargo (Rust's package manager). If you still need to install Rust, follow the instructions on the [official Rust website](https://www.rust-lang.org/learn/get-started).
-
-**Step 2: Install Aderyn using cargo**
-
-Aderyn is currently installed using Cargo, Rust's package manager. Open your command line interface and run the following command:
-```sh
-cargo install aderyn
-```
-This command downloads and installs the Aderyn package.
-
-**Step 3: Verify installation**
-
-After the installation, you can verify that Aderyn is correctly installed by checking its version. In your command line, execute:
-```sh
-aderyn --version
-```
-This command should return the installed version of Aderyn, confirming that the installation was successful.
-
-**Step 4: Update PATH (if necessary)**
-
-If you cannot run the aderyn after installation, you may need to add Cargo's bin directory to your PATH. The exact instructions can vary based on your operating system. Typically, it involves adding ~/.cargo/bin to your PATH in your shell profile script (like .bashrc or .zshrc).
-
-**Step 5: Future Updates**
-
-To update Aderyn to the latest version, you can run the install command again:
-```sh
-cargo install aderyn
-```
-Cargo will replace the existing version with the latest one.
-
 ## Quick Start
 Once Aderyn is installed on your system, you can run it against your Foundry-based codebase to find vulnerabilities in your code.
 

--- a/aderyn/README.md
+++ b/aderyn/README.md
@@ -59,15 +59,11 @@ You can read the [Cyfrin official documentation](https://docs.cyfrin.io) for an 
 [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=dustypomerleau.rust-syntax) - Rust language support for Visual Studio Code
 [Rust Syntax](https://marketplace.visualstudio.com/items?itemName=dustypomerleau.rust-syntax) - Improved Rust syntax highlighting
 
-### Installing Aderyn
-
-You can install Aderyn using Cargo, Rust's package manager, or with `cyfrinup`, the Cyfrin CLI tool.
-
-#### Using Cyfrinup
+### Using Cyfrinup
 
 > Note: If you previously installed aderyn using cargo, run `cargo uninstall aderyn` before using `cyfrinup` to avoid conflicts.
 
-**Step 1: Install Cyfrinup**
+#### Step 1: Install Cyfrinup
 
 Cyfrinup is a CLI tool that simplifies the installation and management of Cyfrin tools. To install Cyfrinup, run the following command in your terminal:
 
@@ -75,11 +71,11 @@ Cyfrinup is a CLI tool that simplifies the installation and management of Cyfrin
 curl -L https://raw.githubusercontent.com/Cyfrin/aderyn/dev/cyfrinup/install | bash
 ```
 
-**Step 2: Update Path**
+#### Step 2: Update Path
 
 The installer will prompt you to run a `source` command. Either run this command, or reload your terminal.
 
-**Step 3: Install Aderyn using Cyfrinup**
+#### Step 3: Install Aderyn using Cyfrinup
 
 After installing Cyfrinup, you can use it to install Aderyn. Run the following command in your terminal:
 
@@ -87,55 +83,19 @@ After installing Cyfrinup, you can use it to install Aderyn. Run the following c
 cyfrinup
 ```
 
-**Step 4: Verify installation**
+#### Step 4: Verify installation
 
 ```sh
 aderyn --version
 ```
 
-**Future Updates**
+#### Future Updates
 
 To update Aderyn to the latest version, you can run the cyfrinup:
 ```sh
 cyfrinup
 ```
 Cyfrinup will replace the existing version with the latest one.
-
-
-#### Using Cargo
-
-**Step 1: Install Rust**
-
-Before installing Aderyn, ensure you have the following:
-* Rust: Aderyn is built in Rust. Before running, you must install Rust and Cargo (Rust's package manager). If you still need to install Rust, follow the instructions on the [official Rust website](https://www.rust-lang.org/learn/get-started).
-
-**Step 2: Install Aderyn using cargo**
-
-Aderyn is currently installed using Cargo, Rust's package manager. Open your command line interface and run the following command:
-```sh
-cargo install aderyn
-```
-This command downloads and installs the Aderyn package.
-
-**Step 3: Verify installation**
-
-After the installation, you can verify that Aderyn is correctly installed by checking its version. In your command line, execute:
-```sh
-aderyn --version
-```
-This command should return the installed version of Aderyn, confirming that the installation was successful.
-
-**Step 4: Update PATH (if necessary)**
-
-If you cannot run the aderyn after installation, you may need to add Cargo's bin directory to your PATH. The exact instructions can vary based on your operating system. Typically, it involves adding ~/.cargo/bin to your PATH in your shell profile script (like .bashrc or .zshrc).
-
-**Step 5: Future Updates**
-
-To update Aderyn to the latest version, you can run the install command again:
-```sh
-cargo install aderyn
-```
-Cargo will replace the existing version with the latest one.
 
 ## Quick Start
 Once Aderyn is installed on your system, you can run it against your Foundry-based codebase to find vulnerabilities in your code.


### PR DESCRIPTION
Remove cargo as a recommended installation process to avoid conflicts with `cyfrinup`.

With this, we'll stop publishing the aderyn package to cargo.