### PR TITLE
Extend support for `reference_declarations()` on `Expression`

### DIFF
--- a/aderyn_core/src/ast/impls/own/expressions.rs
+++ b/aderyn_core/src/ast/impls/own/expressions.rs
@@ -102,16 +102,14 @@ impl Expression {
                     function_call_ops
                         .options
                         .iter()
-                        .map(|opt| opt.referenced_declarations())
-                        .flatten(),
+                        .flat_map(|opt| opt.referenced_declarations()),
                 );
 
                 if let Some(arguments) = function_call_ops.arguments.as_ref() {
                     result.extend(
                         arguments
                             .iter()
-                            .map(|opt| opt.referenced_declarations())
-                            .flatten(),
+                            .flat_map(|opt| opt.referenced_declarations()),
                     );
                 }
 

--- a/aderyn_core/src/ast/impls/own/expressions.rs
+++ b/aderyn_core/src/ast/impls/own/expressions.rs
@@ -84,8 +84,41 @@ impl Expression {
                     result.extend(argument.referenced_declarations());
                 }
             }
+            Expression::Literal(_) => {} // Literal by definition, does not "reference" any declaration!
+            Expression::UnaryOperation(unary_op) => {
+                result.extend(unary_op.sub_expression.referenced_declarations());
+            }
+            Expression::BinaryOperation(binary_op) => {
+                result.extend(binary_op.left_expression.referenced_declarations());
+                result.extend(binary_op.right_expression.referenced_declarations());
+            }
+            Expression::Conditional(conditional) => {
+                result.extend(conditional.true_expression.referenced_declarations());
+                result.extend(conditional.false_expression.referenced_declarations());
+                result.extend(conditional.condition.referenced_declarations());
+            }
+            Expression::FunctionCallOptions(function_call_ops) => {
+                result.extend(
+                    function_call_ops
+                        .options
+                        .iter()
+                        .map(|opt| opt.referenced_declarations())
+                        .flatten(),
+                );
 
-            _ => {}
+                if let Some(arguments) = function_call_ops.arguments.as_ref() {
+                    result.extend(
+                        arguments
+                            .iter()
+                            .map(|opt| opt.referenced_declarations())
+                            .flatten(),
+                    );
+                }
+
+                result.extend(&function_call_ops.expression.referenced_declarations());
+            }
+            Expression::ElementaryTypeNameExpression(_) => (), // TODO: Ignore `TypeName` references for now
+            Expression::NewExpression(_) => (), // TODO: Ignore `TypeName` references for now
         }
 
         result


### PR DESCRIPTION
I find that while writing detectors, we often tend to do 

`if let Expression::Identifier(id) = expr { ..  ...id.referenced_declaration .. } `

`if let Expression::MemberAccess(m) = expr { ..  ...m.referenced_declaration .. } `

Which maybe correct in many places, but a lot of times we just want to know what the expression is referencing, so it's easier and more scalable to have a `referenced_declarations()` on the Expression itself. We've had one so far but it was far out of date. This PR extends support to it 
