### PR TITLE
Performance boost for aderyn 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.26.2",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -3588,6 +3589,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.67",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ exclude = [
     "foundry",
 ]
 
+
 [profile.release]
 codegen-units = 1
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,7 @@ exclude = [
     "bot_ci_cd",
     "foundry",
 ]
+
+[profile.release]
+codegen-units = 1
+lto = true

--- a/aderyn/Cargo.toml
+++ b/aderyn/Cargo.toml
@@ -20,3 +20,5 @@ strum = { version = "0.26", features = ["derive"] }
 notify-debouncer-full = "0.3.1"
 cyfrin-foundry-compilers = { version = "0.3.20-aderyn", features = ["svm-solc"]  }
 
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = "0.6"

--- a/aderyn/src/main.rs
+++ b/aderyn/src/main.rs
@@ -1,5 +1,12 @@
 #![allow(clippy::borrowed_box)]
 
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
 use aderyn::{
     aderyn_is_currently_running_newest_version, debounce_and_run, print_all_detectors_view,
     print_detail_view,


### PR DESCRIPTION
* Alternative allocator kicks in when available based on platform https://crates.io/crates/tikv-jemallocator (For all modes)
* Codegen units = 1 (For release mode)
* Link time optimization = "fat" (For release mode)

TODO:
change to mimalloc instead of jemalloc