### PR TITLE
Fix AST Node - Account for returns in a modifier (To be included in aderynV0.1.9)

### DIFF
--- a/aderyn_core/src/ast/ast_nodes.rs
+++ b/aderyn_core/src/ast/ast_nodes.rs
@@ -639,7 +639,7 @@ ast_node!(
 ast_node!(
     #[derive(Hash)]
     struct Return {
-        function_return_parameters: Option<NodeID>,
+        function_return_parameters: Option<NodeID>, // When returning in a modifier, this can be none
         expression: Option<Expression>,
     }
 );

--- a/aderyn_core/src/ast/ast_nodes.rs
+++ b/aderyn_core/src/ast/ast_nodes.rs
@@ -639,7 +639,7 @@ ast_node!(
 ast_node!(
     #[derive(Hash)]
     struct Return {
-        function_return_parameters: NodeID,
+        function_return_parameters: Option<NodeID>,
         expression: Option<Expression>,
     }
 );


### PR DESCRIPTION
Fix #632


(very important)

Affects at least the contracts with `return` inside modifiers