### PR TITLE
Check Github releases for upgraded version, instead of crates.io

### DIFF
--- a/aderyn/README.md
+++ b/aderyn/README.md
@@ -1,4 +1,9 @@
 
+> ⚠️ **Installing via crates is no longer fully supported. `cyfrinup` is the preferred installation method.**.
+>
+> For the best experience, please remove the legacy crate installation by running `cargo uninstall aderyn`, and use `cyfrinup` instead.
+>
+> Full install instructions are [here](#installation).
 
 <p align="center">
     <br />

--- a/aderyn/src/lib.rs
+++ b/aderyn/src/lib.rs
@@ -114,15 +114,12 @@ pub fn aderyn_is_currently_running_newest_version() -> Result<bool, reqwest::Err
         .build()?;
 
     let latest_version_checker = client
-        .get("https://crates.io/api/v1/crates?q=aderyn&per_page=1")
+        .get("https://api.github.com/repos/Cyfrin/aderyn/releases/latest")
         .send()?;
 
     let data = latest_version_checker.json::<Value>()?;
-
-    let newest_version = data["crates"][0]["newest_version"].to_string();
-    let newest_version = &newest_version[1..newest_version.len() - 1];
-
-    let newest = Version::parse(newest_version).unwrap();
+    let newest =
+        Version::parse(data["tag_name"].as_str().unwrap().replace("v", "").as_str()).unwrap();
     let current = Version::parse(env!("CARGO_PKG_VERSION")).unwrap();
 
     Ok(current >= newest)

--- a/aderyn/src/main.rs
+++ b/aderyn/src/main.rs
@@ -151,9 +151,7 @@ fn main() {
         if let Ok(yes) = aderyn_is_currently_running_newest_version() {
             if !yes {
                 println!();
-                println!(
-                    "NEW VERSION OF ADERYN AVAILABLE! Please run `cargo install aderyn` to fully upgrade the current version"
-                );
+                println!("NEW VERSION OF ADERYN AVAILABLE! Please run `cyfrinup` to upgrade.");
             }
         }
     }


### PR DESCRIPTION
* Check new version tags from Github releases, rather than crates.io.
* Add a warning in the crate README.