### PR TITLE
DO NOT MERGE: Cargo install warning to publish to crates.io

### DIFF
--- a/aderyn/src/main.rs
+++ b/aderyn/src/main.rs
@@ -155,4 +155,13 @@ fn main() {
             }
         }
     }
+
+    println!("----------------------------------------------------------------");
+    println!("|                                                              |");
+    println!("| Aderyn has been installed here using cargo, which is not     |");
+    println!("| recommended for use. Please use the official install script  |");
+    println!("| from the Aderyn repository to ensure the best experience:    |");
+    println!("| https://github.com/Cyfrin/aderyn#installation                |");
+    println!("|                                                              |");
+    println!("----------------------------------------------------------------");
 }


### PR DESCRIPTION
Once approved, this branch will be published to crates.io, and older versions will be yanked.