### PR TITLE
Fix: Allow aderyn to exit without crashing if update-check fails

### DIFF
--- a/aderyn/src/lib.rs
+++ b/aderyn/src/lib.rs
@@ -1,7 +1,7 @@
 use aderyn_driver::detector::{get_all_detectors_names, get_issue_detector_by_name, IssueSeverity};
 use semver::Version;
 use serde_json::Value;
-use std::{error::Error, fs::File, io::Write, path::PathBuf, str::FromStr};
+use std::{fs::File, io::Write, path::PathBuf, str::FromStr};
 use strum::IntoEnumIterator;
 
 pub fn create_aderyn_toml_file_at(directory: String) {

--- a/aderyn/src/lib.rs
+++ b/aderyn/src/lib.rs
@@ -1,7 +1,7 @@
 use aderyn_driver::detector::{get_all_detectors_names, get_issue_detector_by_name, IssueSeverity};
 use semver::Version;
 use serde_json::Value;
-use std::{fs::File, io::Write, path::PathBuf, str::FromStr};
+use std::{error::Error, fs::File, io::Write, path::PathBuf, str::FromStr};
 use strum::IntoEnumIterator;
 
 pub fn create_aderyn_toml_file_at(directory: String) {
@@ -88,21 +88,23 @@ fn right_pad(s: &str, by: usize) -> String {
 
 pub static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 
-pub fn aderyn_is_currently_running_newest_version() -> Result<bool, reqwest::Error> {
+pub fn aderyn_is_currently_running_newest_version() -> Option<bool> {
     let client = reqwest::blocking::Client::builder()
         .user_agent(APP_USER_AGENT)
-        .build()?;
+        .build()
+        .expect("client is unable to initialize");
 
     let latest_version_checker = client
         .get("https://api.github.com/repos/Cyfrin/aderyn/releases/latest")
-        .send()?;
+        .send()
+        .ok()?;
 
-    let data = latest_version_checker.json::<Value>()?;
-    let newest =
-        Version::parse(data["tag_name"].as_str().unwrap().replace('v', "").as_str()).unwrap();
-    let current = Version::parse(env!("CARGO_PKG_VERSION")).unwrap();
+    let data = latest_version_checker.json::<Value>().ok()?;
+    let version_string = data["tag_name"].as_str()?;
+    let newest = Version::parse(version_string.replace('v', "").as_str()).ok()?;
+    let current = Version::parse(env!("CARGO_PKG_VERSION")).expect("Pkg version not available");
 
-    Ok(current >= newest)
+    Some(current >= newest)
 }
 
 #[cfg(test)]
@@ -111,6 +113,6 @@ mod latest_version_checker_tests {
 
     #[test]
     fn can_get_latest_version_from_crate_registry() {
-        assert!(aderyn_is_currently_running_newest_version().is_ok())
+        assert!(aderyn_is_currently_running_newest_version().is_some())
     }
 }

--- a/aderyn/src/main.rs
+++ b/aderyn/src/main.rs
@@ -141,7 +141,7 @@ fn main() {
 
     // Check for updates
     if !cmd_args.skip_update_check {
-        if let Ok(yes) = aderyn_is_currently_running_newest_version() {
+        if let Some(yes) = aderyn_is_currently_running_newest_version() {
             if !yes {
                 println!();
                 println!("NEW VERSION OF ADERYN AVAILABLE! Please run `cyfrinup` to upgrade.");


### PR DESCRIPTION
It's not the end of the world, if we can't do the update checks. Aderyn shouldn't crash 

Fix #751 