### PR TITLE
Update `.is_constructor` -> `.kind() == &FunctionKind::Constructor` for broader version compatiblity 

### DIFF
--- a/aderyn_core/src/detect/high/multiple_constructors.rs
+++ b/aderyn_core/src/detect/high/multiple_constructors.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, error::Error};
 
-use crate::ast::NodeID;
+use crate::ast::{FunctionKind, NodeID};
 
 use crate::{
     capture,
@@ -25,7 +25,7 @@ impl IssueDetector for MultipleConstructorsDetector {
                 ExtractFunctionDefinitions::from(contract)
                     .extracted
                     .iter()
-                    .filter(|function| function.is_constructor)
+                    .filter(|function| function.kind() == &FunctionKind::Constructor)
                     .count()
                     > 1
             })

--- a/aderyn_core/src/detect/low/dead_code.rs
+++ b/aderyn_core/src/detect/low/dead_code.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, error::Error};
 
-use crate::ast::{ASTNode, ContractKind, NodeID, NodeType, Visibility};
+use crate::ast::{ASTNode, ContractKind, FunctionKind, NodeID, NodeType, Visibility};
 
 use crate::{
     capture,
@@ -34,7 +34,7 @@ impl IssueDetector for DeadCodeDetector {
                 f.overrides.is_none()
                     && f.implemented
                     && f.visibility == Visibility::Internal
-                    && !f.is_constructor
+                    && f.kind() != &FunctionKind::Constructor
             })
             .filter(|&f| {
                 if let Some(ASTNode::ContractDefinition(contract)) =


### PR DESCRIPTION
Fix https://github.com/Cyfrin/aderyn/issues/687