### PR TITLE
Fix: Catch only ERC20 functions when reporting unsafe transfer

### DIFF
--- a/aderyn_core/src/detect/low/unsafe_erc20_functions.rs
+++ b/aderyn_core/src/detect/low/unsafe_erc20_functions.rs
@@ -18,7 +18,9 @@ pub struct UnsafeERC20FunctionsDetector {
 impl IssueDetector for UnsafeERC20FunctionsDetector {
     fn detect(&mut self, context: &WorkspaceContext) -> Result<bool, Box<dyn Error>> {
         for member_access in context.member_accesses() {
-            if member_access.member_name == "transferFrom"
+            if member_access.expression.as_ref().type_descriptions().is_some_and(|desc| {
+                desc.type_string.as_ref().is_some_and(|type_string| type_string.contains("ERC20"))
+            }) && member_access.member_name == "transferFrom"
                 || member_access.member_name == "approve"
                 || member_access.member_name == "transfer"
             {

--- a/reports/templegold-report.md
+++ b/reports/templegold-report.md
@@ -937,7 +937,7 @@ The `ecrecover` function is susceptible to signature malleability. This means th
 
 ERC20 functions may not behave as expected. For example: return values are not always meaningful. It is recommended to use OpenZeppelin's SafeERC20 library.
 
-<details><summary>5 Found Instances</summary>
+<details><summary>4 Found Instances</summary>
 
 
 - Found in contracts/amo/Ramos.sol [Line: 195](../tests/2024-07-templegold/protocol/contracts/amo/Ramos.sol#L195)
@@ -956,12 +956,6 @@ ERC20 functions may not behave as expected. For example: return values are not a
 
 	```solidity
 	                quoteToken.approve(address(balancerVault), 0);
-	```
-
-- Found in contracts/fakes/UniswapV2Router02NoEth.sol [Line: 108](../tests/2024-07-templegold/protocol/contracts/fakes/UniswapV2Router02NoEth.sol#L108)
-
-	```solidity
-	        IUniswapV2Pair(pair).transferFrom(msg.sender, pair, liquidity); // send liquidity to pair
 	```
 
 - Found in contracts/v2/templeLineOfCredit/TempleLineOfCredit.sol [Line: 394](../tests/2024-07-templegold/protocol/contracts/v2/templeLineOfCredit/TempleLineOfCredit.sol#L394)


### PR DESCRIPTION
Fix https://github.com/Cyfrin/aderyn/issues/556