### PR TITLE
fix: make install work with non interactive zsh shells

### DIFF
--- a/cyfrinup/install
+++ b/cyfrinup/install
@@ -46,7 +46,7 @@ chmod +x $BIN_PATH
 # Store the correct profile file (i.e. .profile for bash or .zshrc for ZSH).
 case $SHELL in
 */zsh)
-    PROFILE=$HOME/.zshrc
+    PROFILE="${ZDOTDIR-"$HOME"}/.zshenv"
     PREF_SHELL=zsh
     ;;
 */bash)


### PR DESCRIPTION
fix for #778, `.zshenv` is sourced in all shells, including non-interactive