### PR TITLE
Update README.md to include error handling for Windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Cyfrinup is a CLI tool that simplifies the installation and management of Cyfrin
 curl -L https://raw.githubusercontent.com/Cyfrin/aderyn/dev/cyfrinup/install | bash
 ```
 
+If you get a `failed writing body` error in Windows, it's most likely because you don't have Windows Distribution system.
+
+You can fix this by going to Microsoft Store, download Ubuntu, and have it running.
 #### Step 2: Update Path
 
 The installer will prompt you to run a `source` command. Either run this command, or reload your terminal.


### PR DESCRIPTION
I encountered an error that other Windows users trying to use Aderyn can also run into.

The Aderyn installation bash won't run if there's no Windows Distribution.

This can simply be fixed by having a running Ubuntu or other distribution.