### PR TITLE
Feat/more robust installer

### DIFF
--- a/cyfrinup/install
+++ b/cyfrinup/install
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -eo pipefail
 
 # -----------------------------------------------------------
 # Forked from Foundry.
@@ -32,7 +32,8 @@ banner
 
 echo Installing cyfrinup...
 
-CYFRIN_DIR="$HOME/.cyfrin"
+BASE_DIR="${XDG_CONFIG_HOME:-$HOME}"
+CYFRIN_DIR="${CYFRIN_DIR:-"$BASE_DIR/.cyfrin"}"
 CYFRIN_BIN_DIR="$CYFRIN_DIR/bin"
 
 CYFRINUP_URL="https://raw.githubusercontent.com/Cyfrin/aderyn/master/cyfrinup/cyfrinup"
@@ -57,6 +58,10 @@ case $SHELL in
     PROFILE=$HOME/.config/fish/config.fish
     PREF_SHELL=fish
     ;;
+*/ash)
+    PROFILE=$HOME/.profile
+    PREF_SHELL=ash
+    ;;
 *)
     echo "cyfrinup: could not detect shell, manually add ${CYFRIN_BIN_DIR} to your PATH."
     exit 1
@@ -65,8 +70,15 @@ esac
 # Only add cyfrinup if it isn't already in PATH.
 if [[ ":$PATH:" != *":${CYFRIN_BIN_DIR}:"* ]]; then
     # Add the cyfrinup directory to the path and ensure the old PATH variables remain.
-    echo >> $PROFILE && echo "export PATH=\"\$PATH:$CYFRIN_BIN_DIR\"" >> $PROFILE
+    if [[ "$PREF_SHELL" == "fish" ]]; then
+        echo >> "$PROFILE" && echo "fish_add_path -a $CYFRIN_BIN_DIR" >> "$PROFILE"
+    else
+        echo >> "$PROFILE" && echo "export PATH=\"\$PATH:$CYFRIN_BIN_DIR\"" >> "$PROFILE"
+    fi
 fi
+
+# Export the PATH directly in the current session
+export PATH="$PATH:$CYFRIN_BIN_DIR"
 
 echo && echo "Detected your preferred shell is ${PREF_SHELL} and added cyfrinup to PATH. Run 'source ${PROFILE}' or start a new terminal session to use cyfrin."
 echo "Then, simply run 'cyfrinup' to install Cyfrin tool suite"

--- a/cyfrinup/install
+++ b/cyfrinup/install
@@ -47,7 +47,7 @@ chmod +x $BIN_PATH
 # Store the correct profile file (i.e. .profile for bash or .zshrc for ZSH).
 case $SHELL in
 */zsh)
-    PROFILE=$HOME/.zshrc
+    PROFILE="${ZDOTDIR-"$HOME"}/.zshenv"
     PREF_SHELL=zsh
     ;;
 */bash)


### PR DESCRIPTION
Improved the install script for working with docker containers and CI/CD pipelines.

# Changes

Here's a rationale for each change:
## set -eo pipefail instead of just set -e:

Makes the script more robust by failing if any part of a pipeline fails, not just the last command. Helpful for catching errors in commands like `curl` or `sh`

## Added BASE_DIR="${XDG_CONFIG_HOME:-$HOME}":

Follows [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/). You can see this that follows foundry's more recent improvements. It respects user preferences for config locations, instead of just dropping right into $HOME

## Changed CYFRIN_DIR="$HOME/.cyfrin" to CYFRIN_DIR="${CYFRIN_DIR:-"$BASE_DIR/.cyfrin"}":

Allows users to customize installation directory via environment variable

## Changed .zshrc to .zshenv and added ${ZDOTDIR-"$HOME"}:

`.zshenv` is loaded for all shell types (interactive, non-interactive, login, scripts), whereas `.zshrc` is only loaded for interactive shells, meaning it won't be loaded for scripts, Docker containers, or other non-interactive environments where PATH modifications might be needed.

## Added ash shell support:

Matches Foundry's shell support

## Added Fish shell-specific PATH modification:

Matches Foundry's shell support

## Added immediate PATH export:

Makes the tool immediately available in current session so that we can use it in a docker environment where each shell is dropped between commands.

# How to test

1. Make sure you have docker installed and the daemon running
2. Create a new directory and a `Dockerfile` file
3. Place the following contents in it, this is the current way you'd setup your docker container with the current install script.

```dockerfile 
# Base debian build (latest).
FROM mcr.microsoft.com/vscode/devcontainers/base:debian

# Update packages.
RUN apt-get update

# Set the default shell to zsh
ENV SHELL=/usr/bin/zsh

# Running everything under zsh
SHELL ["/usr/bin/zsh", "-c"]

# Dropping privileges
USER vscode

# Install rust
RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && source $HOME/.cargo/env

# Install cyfrinup - you'll see this fails
RUN curl -L https://raw.githubusercontent.com/Cyfrin/aderyn/dev/cyfrinup/install | zsh
RUN cyfrinup 
```

4. Attempt to start up a docker container with cyfrinup/aderyn, it will fail
```bash
docker build -t cyfrin-dev .
```

This is the error:

```
 => ERROR [5/5] RUN cyfrinup                                                                                                     0.1s
------
 > [5/5] RUN cyfrinup:
0.070 zsh:1: command not found: cyfrinup
------
Dockerfile:21
--------------------
  19 |     # Install cyfrinup - you'll see this fails
  20 |     RUN curl -L https://raw.githubusercontent.com/Cyfrin/aderyn/dev/cyfrinup/install | zsh
  21 | >>> RUN cyfrinup 
--------------------
ERROR: failed to solve: process "/usr/bin/zsh -c cyfrinup" did not complete successfully: exit code: 127
```

5. Update the install command by changing this line to use the install script in this branch

```diff
- RUN curl -L https://raw.githubusercontent.com/Cyfrin/aderyn/dev/cyfrinup/install | zsh
+ RUN curl -L https://raw.githubusercontent.com/Cyfrin/aderyn/refs/heads/feat/more-robust-installer/cyfrinup/install | zsh
```

It will work successfully. 

## Testing tear down

You'll have a new docker image in your docker daemon, you can remove it if you'd like. 