### PR TITLE
Audit mode: Entry Points

### DIFF
--- a/aderyn/src/main.rs
+++ b/aderyn/src/main.rs
@@ -76,8 +76,9 @@ pub struct CommandLineArgs {
     skip_update_check: bool,
 
     /// Run in Auditor mode, which only outputs manual audit helpers
-    #[arg(long)]
-    auditor_mode: bool,
+    /// Optional value can specify a specific auditor detector to run (e.g. "entry-points")
+    #[arg(long, num_args = 0..=1, default_missing_value = "all")]
+    audit: Option<String>,
 }
 
 #[derive(Debug, Subcommand)]
@@ -147,7 +148,7 @@ fn main() {
         skip_cloc: cmd_args.skip_cloc,
         skip_update_check: cmd_args.skip_update_check,
         stdout: cmd_args.stdout,
-        auditor_mode: cmd_args.auditor_mode,
+        audit: cmd_args.audit,
         highs_only: cmd_args.highs_only,
         lsp: cmd_args.lsp,
     };

--- a/aderyn_core/src/audit/attack_surface.rs
+++ b/aderyn_core/src/audit/attack_surface.rs
@@ -201,9 +201,12 @@ fn find_address_source_if_function_call(
 
 #[cfg(test)]
 mod attack_surface_detector_tests {
+    use serial_test::serial;
+
     use crate::audit::{attack_surface::AttackSurfaceDetector, auditor::AuditorDetector};
 
     #[test]
+    #[serial]
     fn test_attack_surface_detector() {
         let context = crate::detect::test_utils::load_solidity_source_unit(
             "../tests/contract-playground/src/auditor_mode/ExternalCalls.sol",

--- a/aderyn_core/src/audit/attack_surface.rs
+++ b/aderyn_core/src/audit/attack_surface.rs
@@ -3,6 +3,7 @@ use prettytable::{row, Row};
 use super::auditor::AuditorDetector;
 use crate::{
     ast::{Expression, FunctionCallKind, MemberAccess, NodeID, NodeType, TypeName},
+    audit::auditor::AuditorDetectorNamePool,
     context::{
         browser::{GetClosestAncestorOfTypeX, Peek},
         workspace_context::{ASTNode, WorkspaceContext},
@@ -111,8 +112,8 @@ impl AuditorDetector for AttackSurfaceDetector {
             .collect()
     }
 
-    fn skeletal_clone(&self) -> Box<dyn AuditorDetector> {
-        Box::<AttackSurfaceDetector>::default()
+    fn name(&self) -> String {
+        format!("{}", AuditorDetectorNamePool::AttackSurface)
     }
 }
 

--- a/aderyn_core/src/audit/auditor.rs
+++ b/aderyn_core/src/audit/auditor.rs
@@ -5,15 +5,16 @@ use strum::{Display, EnumString};
 
 use crate::{
     audit::{
-        attack_surface::AttackSurfaceDetector, entry_points::EntryPointsDetector,
+        entry_points::EntryPointsDetector,
         public_functions_no_sender::PublicFunctionsNoSenderChecksDetector,
+        raw_calls::RawCallsDetector,
     },
     context::workspace_context::WorkspaceContext,
 };
 
 pub fn get_all_auditor_detectors() -> Vec<Box<dyn AuditorDetector>> {
     vec![
-        Box::<AttackSurfaceDetector>::default(),
+        Box::<RawCallsDetector>::default(),
         Box::<PublicFunctionsNoSenderChecksDetector>::default(),
         Box::<EntryPointsDetector>::default(),
     ]
@@ -26,7 +27,7 @@ pub fn get_all_auditor_detectors_names() -> Vec<String> {
 #[derive(Debug, PartialEq, EnumString, Display)]
 #[strum(serialize_all = "kebab-case")]
 pub(crate) enum AuditorDetectorNamePool {
-    AttackSurface,
+    RawCalls,
     NoSenderChecks,
     EntryPoints,
     // NOTE: `Undecided` will be the default name (for new bots).
@@ -38,12 +39,12 @@ pub fn get_auditor_detector_by_name(name: &str) -> Box<dyn AuditorDetector> {
     // Expects a valid detector_name
     let detector_name = AuditorDetectorNamePool::from_str(name).unwrap();
     match detector_name {
-        AuditorDetectorNamePool::AttackSurface => Box::<AttackSurfaceDetector>::default(),
+        AuditorDetectorNamePool::RawCalls => Box::<RawCallsDetector>::default(),
         AuditorDetectorNamePool::NoSenderChecks => {
             Box::<PublicFunctionsNoSenderChecksDetector>::default()
         }
         AuditorDetectorNamePool::EntryPoints => Box::<EntryPointsDetector>::default(),
-        AuditorDetectorNamePool::Undecided => Box::<AttackSurfaceDetector>::default(),
+        AuditorDetectorNamePool::Undecided => Box::<RawCallsDetector>::default(),
     }
 }
 

--- a/aderyn_core/src/audit/auditor.rs
+++ b/aderyn_core/src/audit/auditor.rs
@@ -4,7 +4,7 @@ use prettytable::{format, Row, Table};
 
 use crate::{
     audit::{
-        attack_surface::AttackSurfaceDetector,
+        attack_surface::AttackSurfaceDetector, entry_points::EntryPointsDetector,
         public_functions_no_sender::PublicFunctionsNoSenderChecksDetector,
     },
     context::workspace_context::WorkspaceContext,
@@ -14,6 +14,7 @@ pub fn get_auditor_detectors() -> Vec<Box<dyn AuditorDetector>> {
     vec![
         Box::<AttackSurfaceDetector>::default(),
         Box::<PublicFunctionsNoSenderChecksDetector>::default(),
+        Box::<EntryPointsDetector>::default(),
     ]
 }
 

--- a/aderyn_core/src/audit/auditor.rs
+++ b/aderyn_core/src/audit/auditor.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, fmt::Display, str::FromStr};
+use std::{error::Error, str::FromStr};
 
 use prettytable::{format, Row, Table};
 use strum::{Display, EnumString};

--- a/aderyn_core/src/audit/entry_points.rs
+++ b/aderyn_core/src/audit/entry_points.rs
@@ -82,12 +82,15 @@ impl AuditorDetector for EntryPointsDetector {
 
 #[cfg(test)]
 mod entry_points_test {
+    use serial_test::serial;
+
     use crate::{
         audit::{auditor::AuditorDetector, entry_points::EntryPointsDetector},
         detect::test_utils::load_solidity_source_unit,
     };
 
     #[test]
+    #[serial]
     fn test_entry_points() {
         let context = load_solidity_source_unit(
             "../tests/contract-playground/src/auditor_mode/PublicFunctionsWithoutSenderCheck.sol",

--- a/aderyn_core/src/audit/entry_points.rs
+++ b/aderyn_core/src/audit/entry_points.rs
@@ -1,0 +1,101 @@
+use prettytable::{row, Row};
+
+use super::auditor::AuditorDetector;
+use crate::{
+    ast::{FunctionKind, NodeType},
+    context::workspace_context::{ASTNode, WorkspaceContext},
+    detect::helpers::get_implemented_external_and_public_functions,
+};
+use std::{cmp::Ordering, collections::BTreeSet, error::Error};
+
+#[derive(Clone, Eq, PartialEq)]
+pub struct EntryPointsInstance {
+    pub contract_name: String,
+    pub function_name: String,
+    pub function_kind: FunctionKind,
+}
+
+impl Ord for EntryPointsInstance {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let by_contract = self.contract_name.cmp(&other.contract_name);
+        if by_contract == Ordering::Equal {
+            self.function_name.cmp(&other.function_name)
+        } else {
+            by_contract
+        }
+    }
+}
+
+impl PartialOrd for EntryPointsInstance {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[derive(Default)]
+pub struct EntryPointsDetector {
+    // contract_name, function_name
+    found_instances: BTreeSet<EntryPointsInstance>,
+}
+
+impl AuditorDetector for EntryPointsDetector {
+    fn detect(&mut self, context: &WorkspaceContext) -> Result<bool, Box<dyn Error>> {
+        let functions = get_implemented_external_and_public_functions(context);
+        functions.for_each(|function_definition| {
+            if let ASTNode::ContractDefinition(contract_definition) = context
+                .get_closest_ancestor(function_definition.id, NodeType::ContractDefinition)
+                .unwrap()
+            {
+                let contract_name = contract_definition.name.clone();
+                self.found_instances.insert(EntryPointsInstance {
+                    contract_name,
+                    function_name: function_definition.name.clone(),
+                    function_kind: function_definition.kind().clone(),
+                });
+            }
+        });
+        Ok(!self.found_instances.is_empty())
+    }
+
+    fn title(&self) -> String {
+        String::from("Contract Entry Points")
+    }
+
+    fn skeletal_clone(&self) -> Box<dyn AuditorDetector> {
+        Box::<EntryPointsDetector>::default()
+    }
+
+    fn table_titles(&self) -> Row {
+        row!["Contract", "Function Kind", "Function Name"]
+    }
+
+    fn table_rows(&self) -> Vec<Row> {
+        self.found_instances
+            .iter()
+            .map(|instance| {
+                row![instance.contract_name, instance.function_kind, instance.function_name,]
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod public_functions_no_sender_checks {
+    use crate::{
+        audit::{auditor::AuditorDetector, entry_points::EntryPointsDetector},
+        detect::test_utils::load_solidity_source_unit,
+    };
+
+    #[test]
+    fn test_public_functions_no_sender_checks() {
+        let context = load_solidity_source_unit(
+            "../tests/contract-playground/src/auditor_mode/PublicFunctionsWithoutSenderCheck.sol",
+        );
+
+        let mut detector = EntryPointsDetector::default();
+        let found = detector.detect(&context).unwrap();
+        // assert that the detector found an issue
+        assert!(found);
+        assert!(detector.found_instances.len() == 11);
+    }
+}

--- a/aderyn_core/src/audit/entry_points.rs
+++ b/aderyn_core/src/audit/entry_points.rs
@@ -81,14 +81,14 @@ impl AuditorDetector for EntryPointsDetector {
 }
 
 #[cfg(test)]
-mod public_functions_no_sender_checks {
+mod entry_points_test {
     use crate::{
         audit::{auditor::AuditorDetector, entry_points::EntryPointsDetector},
         detect::test_utils::load_solidity_source_unit,
     };
 
     #[test]
-    fn test_public_functions_no_sender_checks() {
+    fn test_entry_points() {
         let context = load_solidity_source_unit(
             "../tests/contract-playground/src/auditor_mode/PublicFunctionsWithoutSenderCheck.sol",
         );

--- a/aderyn_core/src/audit/entry_points.rs
+++ b/aderyn_core/src/audit/entry_points.rs
@@ -3,6 +3,7 @@ use prettytable::{row, Row};
 use super::auditor::AuditorDetector;
 use crate::{
     ast::{FunctionKind, NodeType},
+    audit::auditor::AuditorDetectorNamePool,
     context::workspace_context::{ASTNode, WorkspaceContext},
     detect::helpers::get_implemented_external_and_public_functions,
 };
@@ -61,8 +62,8 @@ impl AuditorDetector for EntryPointsDetector {
         String::from("Contract Entry Points")
     }
 
-    fn skeletal_clone(&self) -> Box<dyn AuditorDetector> {
-        Box::<EntryPointsDetector>::default()
+    fn name(&self) -> String {
+        format!("{}", AuditorDetectorNamePool::EntryPoints)
     }
 
     fn table_titles(&self) -> Row {

--- a/aderyn_core/src/audit/mod.rs
+++ b/aderyn_core/src/audit/mod.rs
@@ -1,3 +1,4 @@
 pub mod attack_surface;
 pub mod auditor;
+pub mod entry_points;
 pub mod public_functions_no_sender;

--- a/aderyn_core/src/audit/mod.rs
+++ b/aderyn_core/src/audit/mod.rs
@@ -1,4 +1,4 @@
-pub mod attack_surface;
 pub mod auditor;
 pub mod entry_points;
 pub mod public_functions_no_sender;
+pub mod raw_calls;

--- a/aderyn_core/src/audit/public_functions_no_sender.rs
+++ b/aderyn_core/src/audit/public_functions_no_sender.rs
@@ -3,6 +3,7 @@ use prettytable::{row, Row};
 use super::auditor::AuditorDetector;
 use crate::{
     ast::{FunctionKind, NodeType},
+    audit::auditor::AuditorDetectorNamePool,
     context::{
         browser::ExtractModifierInvocations,
         workspace_context::{ASTNode, WorkspaceContext},
@@ -98,8 +99,8 @@ impl AuditorDetector for PublicFunctionsNoSenderChecksDetector {
             .collect()
     }
 
-    fn skeletal_clone(&self) -> Box<dyn AuditorDetector> {
-        Box::<PublicFunctionsNoSenderChecksDetector>::default()
+    fn name(&self) -> String {
+        format!("{}", AuditorDetectorNamePool::NoSenderChecks)
     }
 }
 

--- a/aderyn_core/src/audit/public_functions_no_sender.rs
+++ b/aderyn_core/src/audit/public_functions_no_sender.rs
@@ -106,6 +106,8 @@ impl AuditorDetector for PublicFunctionsNoSenderChecksDetector {
 
 #[cfg(test)]
 mod public_functions_no_sender_checks {
+    use serial_test::serial;
+
     use crate::{
         audit::{
             auditor::AuditorDetector,
@@ -115,6 +117,7 @@ mod public_functions_no_sender_checks {
     };
 
     #[test]
+    #[serial]
     fn test_public_functions_no_sender_checks() {
         let context = load_solidity_source_unit(
             "../tests/contract-playground/src/auditor_mode/PublicFunctionsWithoutSenderCheck.sol",

--- a/aderyn_core/src/lib.rs
+++ b/aderyn_core/src/lib.rs
@@ -106,7 +106,7 @@ fn run_auditor_mode(
                 }
             }
         }
-        audit_detectors_with_output.extend(grouped_instances.into_iter());
+        audit_detectors_with_output.extend(grouped_instances);
     }
 
     for (title, (table_titles, table_rows)) in audit_detectors_with_output {

--- a/aderyn_driver/benches/detectors_benchmarks.rs
+++ b/aderyn_driver/benches/detectors_benchmarks.rs
@@ -40,7 +40,7 @@ fn bench_aderyn_on_contract_playground(c: &mut Criterion) {
                 path_includes: None,
                 src: None,
                 stdout: false,
-                auditor_mode: false,
+                audit: None,
                 highs_only: false,
                 lsp: false,
             });

--- a/aderyn_driver/src/driver.rs
+++ b/aderyn_driver/src/driver.rs
@@ -32,7 +32,7 @@ pub struct Args {
     pub skip_cloc: bool,
     pub skip_update_check: bool,
     pub stdout: bool,
-    pub auditor_mode: bool,
+    pub audit: Option<String>,
     pub highs_only: bool,
     pub lsp: bool,
 }
@@ -97,7 +97,7 @@ pub fn drive_with(args: Args, detectors_list: Vec<Box<dyn IssueDetector>>) {
             root_rel_path,
             args.no_snippets,
             args.stdout,
-            args.auditor_mode,
+            args.audit,
             detectors_list,
         )
         .unwrap_or_else(|err| {
@@ -114,7 +114,7 @@ pub fn drive_with(args: Args, detectors_list: Vec<Box<dyn IssueDetector>>) {
             root_rel_path,
             args.no_snippets,
             args.stdout,
-            args.auditor_mode,
+            args.audit,
             detectors_list,
         )
         .unwrap_or_else(|err| {
@@ -132,7 +132,7 @@ pub fn drive_with(args: Args, detectors_list: Vec<Box<dyn IssueDetector>>) {
             root_rel_path,
             args.no_snippets,
             args.stdout,
-            args.auditor_mode,
+            args.audit,
             detectors_list,
         )
         .unwrap_or_else(|err| {


### PR DESCRIPTION
* New audit detector: Entry Points
  * All public and external entry points into the contracts in the workspace
* Rename `attack-surface` to `raw-calls` 
* CLI behaviour change
  * `aderyn --audit` - runs all audit mode detectors
  * `aderyn --audit <detector_name>` runs specific audit mode detector. Example:
  * `aderyn --audit entry-points`