### PR TITLE
feat: remove remappings from aderyn.toml

### DIFF
--- a/aderyn/templates/aderyn.toml
+++ b/aderyn/templates/aderyn.toml
@@ -35,8 +35,6 @@ root = "."
 # exclude = ["src/counters/Counter.sol", "src/others/"]
 # exclude = ["/interfaces/"]
 
-# Remappings used for compiling the contracts.
-# If not specified, Aderyn will try to derive the values from foundry.toml (if present.)
-# That would be the result of calling `foundry remappings`
-# Example:
-# remappings = ["@oz/contracts=lib/openzeppelin-contracts/contracts"]
+# Remappings used for compiling the contracts
+# Aderyn will try to derive the values from foundry.toml (if present.) and `remappings.txt`
+# Specify the remappings in `remappings.txt` and place the file at the `root` indicated above.

--- a/aderyn_driver/src/config_helpers.rs
+++ b/aderyn_driver/src/config_helpers.rs
@@ -14,7 +14,6 @@ pub struct AderynConfig {
     pub root: Option<String>,
     pub src: Option<String>,
     pub exclude: Option<Vec<String>>,
-    pub remappings: Option<Vec<String>>,
     pub include: Option<Vec<String>>,
 }
 
@@ -35,7 +34,6 @@ fn load_aderyn_config(root: &Path) -> Result<AderynConfig, String> {
 
     // Clear empty vectors
     clear_empty_vectors(&mut config.exclude);
-    clear_empty_vectors(&mut config.remappings);
     clear_empty_vectors(&mut config.include);
 
     Ok(config)
@@ -114,19 +112,7 @@ fn interpret_aderyn_config(
         }
     }
 
-    // If config.remappings is some, append each value to remappings if it is not already present
-    let mut local_remappings = remappings.clone();
-    if let Some(config_remappings) = &config.remappings {
-        if let Some(local_remappings) = &mut local_remappings {
-            for item in config_remappings {
-                if !local_remappings.contains(item) {
-                    local_remappings.push(item.clone());
-                }
-            }
-        } else {
-            local_remappings = Some(config_remappings.clone());
-        }
-    }
+    let local_remappings = remappings.clone();
 
     // If config.include is some, append each value to include if it is not already present
     let mut local_include = include.clone();
@@ -227,7 +213,6 @@ mod tests {
             root: Some("CONFIG_ROOT".to_string()),
             src: Some("CONFIG_SRC".to_string()),
             exclude: Some(vec!["CONFIG_EXCLUDE".to_string()]),
-            remappings: Some(vec!["CONFIG_REMAPPINGS".to_string()]),
             include: Some(vec!["CONFIG_SCOPE".to_string()]),
         };
 
@@ -250,11 +235,7 @@ mod tests {
         );
         assert_eq!(
             result.3,
-            Some(vec![
-                "ARG_REMAPPINGS_1".to_string(),
-                "ARG_REMAPPINGS_2".to_string(),
-                "CONFIG_REMAPPINGS".to_string()
-            ])
+            Some(vec!["ARG_REMAPPINGS_1".to_string(), "ARG_REMAPPINGS_2".to_string()])
         );
         assert_eq!(
             result.4,


### PR DESCRIPTION
To make it less confusing, ask the users to write the remappings in `remappings.txt`. That should be enough.

If remappings were filled (for the minority of users to who have used this feature), we  can display a warning saying...these will not be considered. Please specify in remappings.txt.
(wip)
