### PR TITLE
feat: Make `src` single folder instead of vector of paths

### DIFF
--- a/aderyn/src/main.rs
+++ b/aderyn/src/main.rs
@@ -29,7 +29,7 @@ pub struct CommandLineArgs {
     ///
     ///    --src=contracts/
     #[clap(short, long, use_value_delimiter = true)]
-    src: Option<Vec<String>>,
+    src: Option<String>,
 
     /// List of path strings to include, delimited by comma (no spaces).
     ///

--- a/aderyn_driver/src/driver.rs
+++ b/aderyn_driver/src/driver.rs
@@ -25,7 +25,7 @@ use tokio::sync::Mutex;
 pub struct Args {
     pub root: String,
     pub output: String,
-    pub src: Option<Vec<String>>,
+    pub src: Option<String>,
     pub path_excludes: Option<Vec<String>>,
     pub path_includes: Option<Vec<String>>,
     pub no_snippets: bool,
@@ -218,7 +218,7 @@ fn make_context(args: &Args) -> WorkspaceContextWrapper {
 fn obtain_config_values(
     args: &Args,
 ) -> Result<
-    (PathBuf, Option<Vec<String>>, Option<Vec<String>>, Option<Vec<String>>, Option<Vec<String>>),
+    (PathBuf, Option<String>, Option<Vec<String>>, Option<Vec<String>>, Option<Vec<String>>),
     Box<dyn Error>,
 > {
     let mut root_path = PathBuf::from(&args.root);
@@ -255,7 +255,7 @@ fn obtain_config_values(
         if local_src.is_none()
             && (hardhat_config_js_path.exists() || hardhat_config_ts_path.exists())
         {
-            local_src = Some(vec![String::from("contracts")])
+            local_src = Some(String::from("contracts"));
         }
 
         // Also if there is no `remappings.txt` or `remappings` in this case, print a warning!

--- a/aderyn_driver/src/foundry_compiler_helpers.rs
+++ b/aderyn_driver/src/foundry_compiler_helpers.rs
@@ -51,7 +51,7 @@ pub fn get_project(root: &Path, remappings: Vec<Remapping>) -> Project {
 pub fn get_relevant_sources(
     root: &Path,
     solidity_files: CompilerInput,
-    src: &Option<Vec<PathBuf>>,
+    src: &Option<PathBuf>,
     scope: &Option<Vec<String>>,
     exclude: &Option<Vec<String>>,
 ) -> BTreeMap<PathBuf, Source> {
@@ -82,7 +82,7 @@ pub fn get_relevant_sources(
 pub fn get_relevant_pathbufs(
     root: &Path,
     pathbufs: &[PathBuf],
-    src: &Option<Vec<PathBuf>>,
+    src: &Option<PathBuf>,
     scope: &Option<Vec<String>>,
     exclude: &Option<Vec<String>>,
 ) -> Vec<PathBuf> {

--- a/aderyn_driver/src/lib.rs
+++ b/aderyn_driver/src/lib.rs
@@ -19,9 +19,9 @@ fn ensure_valid_root_path(root_path: &Path) -> PathBuf {
     utils::canonicalize(root_path).unwrap()
 }
 
-fn passes_src(src: &Option<Vec<PathBuf>>, solidity_file: &Path) -> bool {
-    if let Some(sources) = src {
-        return sources.iter().any(|s| solidity_file.starts_with(s));
+fn passes_src(src: &Option<PathBuf>, solidity_file: &Path) -> bool {
+    if let Some(source) = src {
+        return solidity_file.starts_with(source);
     }
     true
 }

--- a/aderyn_driver/src/process_auto.rs
+++ b/aderyn_driver/src/process_auto.rs
@@ -19,19 +19,14 @@ use crate::ensure_valid_root_path;
 
 pub fn with_project_root_at(
     root_path: &Path,
-    src: &Option<Vec<String>>,
+    src: &Option<String>,
     exclude: &Option<Vec<String>>,
     remappings: &Option<Vec<String>>,
     scope: &Option<Vec<String>>,
     lsp_mode: bool,
 ) -> Vec<WorkspaceContext> {
     let root = utils::canonicalize(root_path).unwrap();
-    let src = src.clone().map(|sources| {
-        sources
-            .into_iter()
-            .map(|source| utils::canonicalize(root.join(source)).unwrap())
-            .collect::<Vec<_>>()
-    });
+    let src = src.clone().map(|source| utils::canonicalize(root.join(source)).unwrap());
 
     let solidity_files = get_compiler_input(&root);
     let sources = get_relevant_sources(&root, solidity_files, &src, scope, exclude);
@@ -107,7 +102,7 @@ pub fn with_project_root_at(
 
 fn create_workspace_context_from_stdout(
     stdout: String,
-    src: &Option<Vec<PathBuf>>,
+    src: &Option<PathBuf>,
     scope: &Option<Vec<String>>,
     exclude: &Option<Vec<String>>,
     root_path: &Path,
@@ -181,7 +176,7 @@ fn is_demarcation_line(
     scope: &Option<Vec<String>>,
     exclude: &Option<Vec<String>>,
     root_path: &Path,
-    src: &Option<Vec<PathBuf>>,
+    src: &Option<PathBuf>,
     absolute_root_path_str: &str,
 ) -> (bool, Option<String>) {
     if line.starts_with("======= ") {

--- a/aderyn_driver/src/project_compiler_tests.rs
+++ b/aderyn_driver/src/project_compiler_tests.rs
@@ -12,7 +12,7 @@ mod project_compiler_grouping_tests {
     #[test]
     fn foundry_nft_f23() {
         let project_root_str = "../tests/foundry-nft-f23";
-        let src = &Some(vec![PathBuf::from_str("src/").unwrap()]);
+        let src = &Some(PathBuf::from_str("src/").unwrap());
         test_grouping_files_to_compile(project_root_str, src, &None, &None);
     }
 
@@ -25,20 +25,20 @@ mod project_compiler_grouping_tests {
     #[test]
     fn contract_playground() {
         let project_root_str = "../tests/contract-playground";
-        let src = &Some(vec![PathBuf::from_str("src/").unwrap()]);
+        let src = &Some(PathBuf::from_str("src/").unwrap());
         test_grouping_files_to_compile(project_root_str, src, &None, &None);
     }
 
     #[test]
     fn ccip_develop() {
         let project_root_str = "../tests/ccip-contracts/contracts";
-        let src = &Some(vec![PathBuf::from_str("src/v0.8/").unwrap()]);
+        let src = &Some(PathBuf::from_str("src/v0.8/").unwrap());
         test_grouping_files_to_compile(project_root_str, src, &None, &None);
     }
 
     fn test_grouping_files_to_compile(
         project_root_str: &str,
-        src: &Option<Vec<PathBuf>>,
+        src: &Option<PathBuf>,
         scope: &Option<Vec<String>>,
         exclude: &Option<Vec<String>>,
     ) {


### PR DESCRIPTION
Although this is technically not a backwards compatible change, because everywhere (in help section + aderyn.toml) we've only ever shown examples of single folder src, this maybe can slide..