### PR TITLE
tech-debt: Inherit dependencies from workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,42 @@ exclude = [
     "foundry",
 ]
 
+[workspace.dependencies]
+aderyn_core = { version = "0.5.0", path = "aderyn_core" }
+aderyn_driver = { version = "0.5.0", path = "aderyn_driver" }
+clap = "4.4.6"
+criterion = "0.5.1"
+crossbeam-channel = "0.5.9"
+cyfrin-foundry-compilers = "0.3.20-aderyn"
+cyfrin-foundry-config = "0.2.1"
+derive_more = "0.99.18"
+eyre = "0.6.12"
+field_access = "0.1.8"
+ignore = "0.4.21"
+lazy-regex = "3.2.0"
+lazy_static = "1.5.0"
+log = "0.4.22"
+notify-debouncer-full = "0.3.1"
+num-bigint = "0.4"
+num-traits = "0.2"
+once_cell = "1.19.0"
+phf = "0.11.2"
+prettytable = "0.10.0"
+rayon = "1.8.0"
+reqwest = { version = "0.12.2", default-features = false }
+semver = "1.0.22"
+serde = "1.0.160"
+serde-sarif = "0.4.2"
+serde_json = "1.0.96"
+serde_repr = "0.1.12"
+serial_test = "3.0.0"
+simple-logging = "2.0.2"
+strum = "0.26"
+termcolor = "1.4.1"
+tokio = "1.40.0"
+toml = "0.8.13"
+tower-lsp = "0.20.0"
+
 [profile.release]
 codegen-units = 1
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,10 @@
 [workspace]
+resolver="2"
+
 members = [
     "aderyn",
     "aderyn_core",
     "aderyn_driver",
-]
-
-resolver="1"
-
-exclude = [
-    "bot_ci_cd",
-    "foundry",
 ]
 
 [workspace.dependencies]

--- a/aderyn/Cargo.toml
+++ b/aderyn/Cargo.toml
@@ -12,18 +12,18 @@ homepage = "https://github.com/cyfrin/aderyn"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aderyn_driver = { path  = "../aderyn_driver", version = "0.5.0" }
-clap = { version = "4.4.6", features = ["derive"] }
-reqwest = { version = "0.12.2", default-features = false, features = ["blocking", "json", "rustls-tls"] }
-semver = "1.0.22"
-serde = { version = "1.0.160", features = ["derive"] }
-serde_json = { version = "1.0.96", features = ["preserve_order"] }
-strum = { version = "0.26", features = ["derive"] }
-notify-debouncer-full = "0.3.1"
-cyfrin-foundry-compilers = { version = "0.3.20-aderyn", features = ["svm-solc"]  }
-termcolor = "1.4.1"
-tokio = { version = "1.40.0", features = ["full"] }
-tower-lsp = "0.20.0"
-log = "0.4.22"
-simple-logging = "2.0.2"
-lazy_static = "1.5.0"
+aderyn_driver = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+reqwest = { workspace = true, features = ["blocking", "json", "rustls-tls"] }
+semver = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["preserve_order"] }
+strum = { workspace = true, features = ["derive"] }
+notify-debouncer-full = { workspace = true }
+cyfrin-foundry-compilers = { workspace = true, features = ["svm-solc"] }
+termcolor = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tower-lsp = { workspace = true }
+log = { workspace = true }
+simple-logging = { workspace = true }
+lazy_static = { workspace = true }

--- a/aderyn_core/Cargo.toml
+++ b/aderyn_core/Cargo.toml
@@ -9,30 +9,28 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-crossbeam-channel = "0.5.9"
-eyre = "0.6.12"
-ignore = "0.4.21"
-phf = { version = "0.11.2", features = ["macros"] }
-prettytable = "0.10.0"
-rayon = "1.8.0"
-semver = "1.0.20"
-serde = { version = "1.0.160", features = ["derive"] }
-serde_json = { version = "1.0.96", features = ["preserve_order"] }
-serde-sarif = "0.4.2"
-serde_repr = "0.1.12"
-strum = { version = "0.26", features = ["derive"] }
-toml = "0.8.2"
-cyfrin-foundry-compilers = { version = "0.3.20-aderyn", features = [
-    "svm-solc",
-] }
-num-bigint = "0.4"
-num-traits = "0.2"
-lazy-regex = "3.2.0"
-derive_more = "0.99.18"
+crossbeam-channel = { workspace = true }
+eyre = { workspace = true }
+ignore = { workspace = true }
+phf = { workspace = true, features = ["macros"] }
+prettytable = { workspace = true }
+rayon = { workspace = true }
+semver = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["preserve_order"] }
+serde-sarif = { workspace = true }
+serde_repr = { workspace = true }
+strum = { workspace = true, features = ["derive"] }
+toml = { workspace = true }
+cyfrin-foundry-compilers = { workspace = true, features = ["svm-solc"] }
+num-bigint = { workspace = true }
+num-traits = { workspace = true }
+lazy-regex = { workspace = true }
+derive_more = { workspace = true }
 
 [dev-dependencies]
-serial_test = "3.0.0"
-once_cell = "1.19.0"
+serial_test = { workspace = true }
+once_cell = { workspace = true }
 
 [lib]
 doctest = false

--- a/aderyn_driver/Cargo.toml
+++ b/aderyn_driver/Cargo.toml
@@ -9,20 +9,20 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aderyn_core = { path  = "../aderyn_core", version = "0.5.0" }
-rayon = "1.8.0"
-cyfrin-foundry-compilers = { version = "0.3.20-aderyn", features = ["svm-solc"]   }
-serde_json = { version = "1.0.96", features = ["preserve_order"] }
-serde = { version = "1.0.160", features = ["derive"] }
-serde_repr = "0.1.12"
-cyfrin-foundry-config = { version = "0.2.1" }
-toml = "0.8.13"
-field_access = "0.1.8"
-tokio = { version = "1.40.0", features = ["full"] }
-tower-lsp = "0.20.0"
+aderyn_core = { workspace = true }
+rayon = { workspace = true }
+cyfrin-foundry-compilers = { workspace = true, features = ["svm-solc"] }
+serde_json = { workspace = true, features = ["preserve_order"] }
+serde = { workspace = true, features = ["derive"] }
+serde_repr = { workspace = true }
+cyfrin-foundry-config = { workspace = true }
+toml = { workspace = true }
+field_access = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tower-lsp = { workspace = true }
 
 [dev-dependencies]
-criterion = "0.5.1"
+criterion = { workspace = true }
 
 [[bench]]
 name = "detectors_benchmarks"


### PR DESCRIPTION
DRY dependencies ✅

Ref: https://mainmatter.com/blog/2024/03/18/cargo-autoinherit/


* No Change to Cargo.lock file 🙌 

* Also update Cargo manifest resolver version