### PR TITLE
fix: typos and improve comment clarity across aderyn_core

### DIFF
--- a/aderyn_core/src/ast/impls/ctx/utils.rs
+++ b/aderyn_core/src/ast/impls/ctx/utils.rs
@@ -85,7 +85,7 @@ impl FunctionCall {
             _ => None,
         }
     }
-    /// Returns the function definition or variable declarartion referenced by the function call.
+    /// Returns the function definition or variable declaration referenced by the function call.
     /// Also see [`FunctionCall::suspected_target_function`]
     #[inline]
     pub fn suspected_function_selector(&self, context: &WorkspaceContext) -> Option<String> {
@@ -101,7 +101,7 @@ impl FunctionCall {
                 let suspect = context.nodes.get(id)?;
                 match suspect {
                     ASTNode::FunctionDefinition(func) => func.function_selector.clone(),
-                    // could be referencing a public state variable (psuedo getter method)
+                    // could be referencing a public state variable (pseudo getter method)
                     ASTNode::VariableDeclaration(var) => var.function_selector.clone(),
                     _ => None,
                 }

--- a/aderyn_core/src/context/flow/voids.rs
+++ b/aderyn_core/src/context/flow/voids.rs
@@ -8,7 +8,7 @@ pub enum CfgStartNode {
     StartModifierBody(AstNodeId),   // Modifier Definition ID
     StartBlock(AstNodeId),          // Block Node ID
     StartUncheckedBlock(AstNodeId), // Unchecked Block ID
-    StartIf(AstNodeId),             // If Statemtnt ID
+    StartIf(AstNodeId),             // If Statement ID
     StartIfCond,
     StartIfTrue,
     StartIfFalse,

--- a/aderyn_core/src/context/router/internal_calls.rs
+++ b/aderyn_core/src/context/router/internal_calls.rs
@@ -98,7 +98,7 @@ impl Router {
     /// 1. regular call like `xyz()`:
     ///     - starting point = base contract
     /// 2. laidback super call `super.xyz()`:
-    ///     - starting point = calling contrat's parent in the inheritance tree of base contract
+    ///     - starting point = calling contract's parent in the inheritance tree of base contract
     /// 3. explicit super call `Grandparent.xyz()`:
     ///     - starting point = Grandparent contract in the inheritance tree of the base contract
     ///

--- a/aderyn_core/src/detect/high/const_func_changes_state.rs
+++ b/aderyn_core/src/detect/high/const_func_changes_state.rs
@@ -37,7 +37,7 @@ impl IssueDetector for ConstantFunctionChangesStateDetector {
             // Now, investigate the function to see if there is scope for any state variable changes
             let mut tracker = StateVariableChangeTracker { state_var_has_changed: false, context };
 
-            // Keep legacy for this because it is for solc version beloe 0.5.0 and the function
+            // Keep legacy for this because it is for solc version below 0.5.0 and the function
             // selectors don't exist
             let callgraph = CallGraphConsumer::get_legacy(
                 context,

--- a/aderyn_core/src/detect/low/assert_state_change.rs
+++ b/aderyn_core/src/detect/low/assert_state_change.rs
@@ -106,7 +106,7 @@ mod assert_state_change_tracker {
 }
 
 #[cfg(test)]
-mod asert_state_changes_tests {
+mod assert_state_changes_tests {
 
     use crate::detect::{
         detector::IssueDetector, low::assert_state_change::AssertStateChangeDetector,


### PR DESCRIPTION
declarartion → declaration
psuedo → pseudo
Statemtnt → Statement
contrat → contract
beloe → below
asert_state_changes_tests → assert_state_changes_tests (test module name)