### PR TITLE
chore: add vscode links to aderyn help menu and remove beta status for mcp

### DIFF
--- a/aderyn/src/main.rs
+++ b/aderyn/src/main.rs
@@ -17,23 +17,20 @@ use std::path::PathBuf;
     author,
     version,
     about = indoc!{
-        r#"Aderyn - Rust based Solidity Static Analyzer
+        r#"Aderyn - Rust based Solidity Static Analyzer (~45k+ total downloads)
 
         CLI Quickstart:
             cd my-solidity-project/
             aderyn
 
-        Official VS Code Extension: (1800+ downloads)
+        VS Code Extension: (1800+ downloads)
             https://marketplace.visualstudio.com/items?itemName=Cyfrin.aderyn
 
         Github Action CI Assistant:
             https://github.com/marketplace/actions/aderyn-ci-assistant
 
         Tip: Run `aderyn init` in the workspace root to create a config file for customizing the scan
-
-        Help Aderyn stay open source by giving us a star on Github - https://github.com/cyfrin/aderyn
-
-        Stats: ~45k total downloads
+        Help Aderyn stay open source. Give a star to https://github.com/cyfrin/aderyn
 
     "#},
     group(ArgGroup::new("stdout_dependent").requires("stdout")),


### PR DESCRIPTION
* Show links to VS Code
* Mark skip-update-check as hidden argument
* Remove MCP from beta