### PR TITLE
fix typo: add missing space after period.

### DIFF
--- a/aderyn_core/src/detect/high/reentrancy_state_change.rs
+++ b/aderyn_core/src/detect/high/reentrancy_state_change.rs
@@ -99,7 +99,7 @@ impl IssueDetector for ReentrancyStateChangeDetector {
 
     fn description(&self) -> String {
         String::from(
-            "Changing state after an external call can lead to re-entrancy attacks.\
+            "Changing state after an external call can lead to re-entrancy attacks. \
         Use the checks-effects-interactions pattern to avoid this issue.",
         )
     }


### PR DESCRIPTION
Since line continuation escape (backslash) is being used, we have to manually manage punctuation at the breakpoint. I noticed the missing space so adding it via this pull request.